### PR TITLE
Implement Home Assistant Forecast.Solar Adapter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,9 +33,11 @@ API_PORT=8001
 # LONGITUDE=9.1900
 # PV_CAPACITY_KWP=5
 
-# Home Assistant Settings (if energy_monitor_adapter=home_assistant)
+# Home Assistant Settings
 # HOME_ASSISTANT_URL=http://YOUR_HA_IP_OR_HOSTNAME:8123
 # HOME_ASSISTANT_TOKEN=YOUR_LONG_LIVED_ACCESS_TOKEN
+
+# Energy Monitor Adapter (if energy_monitor_adapter=home_assistant)
 # HA_ENTITY_SOLAR_PRODUCTION=sensor.your_solar_production_entity # (W or kW)
 # HA_ENTITY_HOUSE_CONSUMPTION=sensor.your_house_consumption_entity # (W or kW - Must exclude miner!)
 # HA_ENTITY_GRID_POWER=sensor.your_grid_power_entity # (W or kW)
@@ -48,6 +50,25 @@ API_PORT=8001
 # HA_BATTERY_NOMINAL_CAPACITY_WH=10000.0 # Optional: If you have a battery but no capacity sensor
 # HA_GRID_POSITIVE_EXPORT=false # Set to true if positive grid power means EXPORTING
 # HA_BATTERY_POSITIVE_CHARGE=true # Set to true if positive battery power means CHARGING
+
+# Forecast Provider Adapter (if forecast_provider_adapter=home_assistant)
+# HA_ENTITY_SOLAR_FORECAST_POWER_ACTUAL_H=sensor.your_solar_forecast_power_actual_entity # (W or kW)
+# HA_ENTITY_SOLAR_FORECAST_POWER_NEXT_1H=sensor.your_solar_forecast_power_next_1h_entity # (W or kW)
+# HA_ENTITY_SOLAR_FORECAST_POWER_NEXT_12H=sensor.your_solar_forecast_power_next_12h_entity # (W or kW)
+# HA_ENTITY_SOLAR_FORECAST_POWER_NEXT_24H=sensor.your_solar_forecast_power_next_24h_entity # (W or kW)
+# HA_ENTITY_SOLAR_FORECAST_ENERGY_ACTUAL_H=sensor.your_solar_forecast_energy_actual_entity # (Wh or kWh)
+# HA_ENTITY_SOLAR_FORECAST_ENERGY_NEXT_1H=sensor.your_solar_forecast_energy_next_1h_entity # (Wh or kWh)
+# HA_ENTITY_SOLAR_FORECAST_ENERGY_NEXT_24H=sensor.your_solar_forecast_energy_next_24h_entity # (Wh or kWh)
+# HA_ENTITY_SOLAR_FORECAST_ENERGY_REMAINING_TODAY=sensor.your_solar_forecast_energy_remaining_today_entity # (Wh or kWh)
+# HA_UNIT_SOLAR_FORECAST_POWER_ACTUAL_H=W # W or kW (optional, default W)
+# HA_UNIT_SOLAR_FORECAST_POWER_NEXT_1H=W # W or kW (optional, default W)
+# HA_UNIT_SOLAR_FORECAST_POWER_NEXT_12H=W # W or kW (optional, default W)
+# HA_UNIT_SOLAR_FORECAST_POWER_NEXT_24H=W # W or kW (optional, default W)
+# HA_UNIT_SOLAR_FORECAST_ENERGY_ACTUAL_H=kWh # Wh or kWh (optional, default kWh)
+# HA_UNIT_SOLAR_FORECAST_ENERGY_NEXT_1H=kWh # Wh or kWh (optional, default kWh)
+# HA_UNIT_SOLAR_FORECAST_ENERGY_NEXT_24H=kWh # Wh or kWh (optional, default kWh)
+# HA_UNIT_SOLAR_FORECAST_ENERGY_REMAINING_TODAY=kWh # Wh or kWh (optional, default kWh)
+
 
 # Scheduler
 SCHEDULER_INTERVAL_SECONDS=5

--- a/.env.example
+++ b/.env.example
@@ -37,7 +37,8 @@ API_PORT=8001
 # HOME_ASSISTANT_URL=http://YOUR_HA_IP_OR_HOSTNAME:8123
 # HOME_ASSISTANT_TOKEN=YOUR_LONG_LIVED_ACCESS_TOKEN
 
-# Energy Monitor Adapter (if energy_monitor_adapter=home_assistant)
+# Energy Monitor Adapter (if ENERGY_MONITOR_ADAPTER=home_assistant)
+# ENERGY_MONITOR_ADAPTER=home_assistant
 # HA_ENTITY_SOLAR_PRODUCTION=sensor.your_solar_production_entity # (W or kW)
 # HA_ENTITY_HOUSE_CONSUMPTION=sensor.your_house_consumption_entity # (W or kW - Must exclude miner!)
 # HA_ENTITY_GRID_POWER=sensor.your_grid_power_entity # (W or kW)
@@ -51,7 +52,8 @@ API_PORT=8001
 # HA_GRID_POSITIVE_EXPORT=false # Set to true if positive grid power means EXPORTING
 # HA_BATTERY_POSITIVE_CHARGE=true # Set to true if positive battery power means CHARGING
 
-# Forecast Provider Adapter (if forecast_provider_adapter=home_assistant)
+# Forecast Provider Adapter (if FORECAST_PROVIDER_ADAPTER=home_assistant)
+# FORECAST_PROVIDER_ADAPTER=home_assistant
 # HA_ENTITY_SOLAR_FORECAST_POWER_ACTUAL_H=sensor.your_solar_forecast_power_actual_entity # (W or kW)
 # HA_ENTITY_SOLAR_FORECAST_POWER_NEXT_1H=sensor.your_solar_forecast_power_next_1h_entity # (W or kW)
 # HA_ENTITY_SOLAR_FORECAST_POWER_NEXT_12H=sensor.your_solar_forecast_power_next_12h_entity # (W or kW)

--- a/.env.example
+++ b/.env.example
@@ -22,9 +22,6 @@ SQLITE_DB_FILE=./edgemining.db
 # API Settings
 API_PORT=8001
 
-# Adapter Selection (Optional - defaults are in settings.py)
-# NOTIFICATION_ADAPTER=telegram
-
 # Notification Settings
 # Telegram Settings (if notification_adapter=telegram)
 # NOTIFICATION_ADAPTER=telegram

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The project uses **Hexagonal Architecture (Ports and Adapters)** to clearly sepa
 
 You can run the application in different modes via the main entry point:
 
-1. **Standard Mode (Default):** Starts the main automation loop that checks miners at regular intervals and starts a REST API (FastAPI) server to interact with the system programmatically.
+1. **Standard Mode (Default):** Starts the main automation loop that checks available energy and controls miners at regular intervals. Starts a REST API (FastAPI) server also to interact with the system programmatically.
 ```bash
 python -m edge_mining
 # Or by explicitly specifying

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The project uses **Hexagonal Architecture (Ports and Adapters)** to clearly sepa
     ```
 4.  **Configure environment variables:**
     Copy `.env.example` to `.env` and change the values ​​according to your configuration (API keys, select the desired adapters).
-    **Note:** If you use the `home_assistant_api` adapter for energy monitoring, make sure to configure the following correctly:
+    **Note:** If you use the `home_assistant_api` adapter for energy monitoring and forecast provider, make sure to configure the following correctly:
     - `HOME_ASSISTANT_URL` and `HOME_ASSISTANT_TOKEN`.
     - The `HA_ENTITY_*` IDs corresponding to your sensors in Home Assistant.
     - **Important:** The `HA_ENTITY_HOUSE_CONSUMPTION` entity should represent the house consumption *excluding* the miner load. You may need to create a `template sensor` in Home Assistant for this.
@@ -66,7 +66,7 @@ The API will be available at `http://localhost:8001` (or the configured address 
 
 - **Energy Monitor:** `dummy`, `home_assistant` (*new*)
 - **Miner Controller:** `dummy`
-- **Forecast Provider:** `dummy`
+- **Forecast Provider:** `dummy`, `home_assistant` (*new*)
 - **Persistence:** `in_memory`, `sqlite` (*new*)
 - **Notification:** `dummy`, `telegram` (*new*)
 - **Interaction:** `cli`, `api`(*new*)

--- a/edge_mining/__main__.py
+++ b/edge_mining/__main__.py
@@ -28,14 +28,14 @@ async def main_async():
     
     # --- Dependency Injection ---
     try:
-        config_service, orchestrator_service = configure_dependencies(logger, settings)
+        action_service, config_service, orchestrator_service = configure_dependencies(logger, settings)
     except Exception as e:
         logger.critical("Failed to configure dependencies. Exiting.")
         sys.exit(1)
         
     # Inject services into CLI and API
-    set_cli_services(config_service, orchestrator_service, logger)
-    set_api_services(config_service, orchestrator_service, logger)
+    set_cli_services(action_service, config_service, orchestrator_service, logger)
+    set_api_services(action_service, config_service, orchestrator_service, logger)
     
     # --- Determine Run Mode ---
     # Example: Use command-line argument to choose mode

--- a/edge_mining/__main__.py
+++ b/edge_mining/__main__.py
@@ -20,8 +20,8 @@ from edge_mining.adapters.infrastructure.api.main_api import app as fastapi_app,
 
 from edge_mining.bootstrap import configure_dependencies
 
-logger = TerminalLogger()
 settings = AppSettings()
+logger = TerminalLogger(LOG_LEVEL=settings.log_level)
 
 async def main_async():
     logger.welcome()

--- a/edge_mining/adapters/domain/energy_monitoring/home_assistant_api.py
+++ b/edge_mining/adapters/domain/energy_monitoring/home_assistant_api.py
@@ -1,34 +1,16 @@
 """Home Assistant API adapter (Implementation of Port) for the energy provisioning of Edge Mining Application using the Home Assistant API"""
 
-"""
-The REST API for Home Assistant has been superseded by the websocket API.
-I use it only for simplicity, in the future I plan to switch to websocket API
-
-https://github.com/home-assistant/architecture/discussions/1074#discussioncomment-9196867
-
-and
-
-https://github.com/home-assistant/developers.home-assistant/pull/2150
-"""
-import logging
-from typing import Optional, Tuple
+from typing import Optional
 from datetime import datetime
-import math # For isnan
-
-
-try:
-    from homeassistant_api import Client
-except ImportError:
-    raise ImportError("Please install 'homeassistant_api' (`pip install homeassistant_api`) to use the Home Assistant energy monitor.")
-
 
 from edge_mining.domain.energy.ports import EnergyMonitorPort
-from edge_mining.domain.common import Watts, Percentage, WattHours, Timestamp
+from edge_mining.shared.logging.port import LoggerPort
+from edge_mining.domain.common import Watts, WattHours, Timestamp
 from edge_mining.domain.energy.value_objects import EnergyStateSnapshot, BatteryState
 
-logger = logging.getLogger(__name__)
+from edge_mining.adapters.infrastructure.homeassistant.homeassistant_api import BaseHomeAssistantAPI
 
-class HomeAssistantEnergyMonitor(EnergyMonitorPort):
+class HomeAssistantEnergyMonitor(BaseHomeAssistantAPI, EnergyMonitorPort):
     """
     Fetches energy data from a Home Assistant instance via its REST API.
 
@@ -51,10 +33,11 @@ class HomeAssistantEnergyMonitor(EnergyMonitorPort):
         unit_battery_power: str = "W",
         battery_capacity_wh: Optional[float] = None,
         grid_positive_export: bool = False, # True if positive grid = export
-        battery_positive_charge: bool = True # True if positive battery = charge
+        battery_positive_charge: bool = True, # True if positive battery = charge
+        logger: LoggerPort = None
     ):
-        if not api_url or not token:
-            raise ValueError("Home Assistant URL and Token are required.")
+        # Initialize the HomeAssistant API base class
+        super(HomeAssistantEnergyMonitor, self).__init__(api_url, token, logger)
 
         self.entity_solar = entity_solar
         self.entity_consumption = entity_consumption
@@ -69,85 +52,18 @@ class HomeAssistantEnergyMonitor(EnergyMonitorPort):
         self.grid_positive_export = grid_positive_export
         self.battery_positive_charge = battery_positive_charge
 
-        logger.info(f"Initializing HomeAssistantEnergyMonitor for {api_url}")
-        logger.debug(f"Entities Configured: Solar='{entity_solar}', Consumption='{entity_consumption}', "
-                     f"Grid='{entity_grid}', BatterySOC='{entity_battery_soc}', BatteryPower='{entity_battery_power}'")
-        logger.debug(f"Units: Solar='{unit_solar}', Consumption='{unit_consumption}', "
-                     f"Grid='{unit_grid}', BatteryPower='{unit_battery_power}'")
-        logger.debug(f"Conventions: Grid Positive Export='{grid_positive_export}', "
-                     f"Battery Positive Charge='{battery_positive_charge}'")
+        self.logger.debug(f"Entities Configured: Solar='{entity_solar}', Consumption='{entity_consumption}', "
+                    f"Grid='{entity_grid}', BatterySOC='{entity_battery_soc}', BatteryPower='{entity_battery_power}'")
+        self.logger.debug(f"Units: Solar='{unit_solar}', Consumption='{unit_consumption}', "
+                    f"Grid='{unit_grid}', BatteryPower='{unit_battery_power}'")
+        self.logger.debug(f"Conventions: Grid Positive Export='{grid_positive_export}', "
+                    f"Battery Positive Charge='{battery_positive_charge}'")
+        
         if self.battery_capacity:
-             logger.debug(f"Static Battery Capacity: {self.battery_capacity} Wh")
-
-
-        # Initialize Home Assistant client
-        try:
-            self.client = Client(api_url, token)
-            # Test connection during initialization (optional but recommended)
-            self.client.get_config()
-            logger.info("Successfully connected to Home Assistant API.")
-        except Exception as e:
-            logger.error(f"An unexpected error occurred connecting to Home Assistant: {e}")
-            raise ConnectionError(f"Unexpected error connecting to Home Assistant: {e}") from e
-
-
-    def _get_entity_state(self, entity_id: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
-        """Safely retrieves the state and unit of an entity."""
-        if not entity_id:
-            return None, None
-        try:
-            entity = self.client.get_entity(entity_id=entity_id)
-            # Check if state is unavailable or unknown
-            state = entity.state.state # The actual value as a string
-            if state is None or state.lower() in ["unavailable", "unknown"]:
-                logger.warning(f"Home Assistant entity '{entity_id}' is unavailable or unknown.")
-                return None, None
-
-            unit = entity.state.attributes.get("unit_of_measurement")
-            logger.debug(f"Fetched HA entity '{entity_id}': State='{state}', Unit='{unit}'")
-            return state, unit
-        except Exception as e:
-            logger.error(f"Unexpected error getting Home Assistant entity '{entity_id}': {e}")
-            return None, None
-
-
-    def _parse_power(self, state: Optional[str], configured_unit: str, entity_id_for_log: str) -> Optional[Watts]:
-        """Parses state string to Watts, handling units (W/kW) and errors."""
-        if state is None:
-            return None
-        try:
-            value = float(state)
-            if math.isnan(value):
-                logger.warning(f"Parsed NaN value for entity '{entity_id_for_log}', state='{state}'. Treating as missing.")
-                return None
-            if configured_unit == "kw":
-                value *= 1000 # Convert kW to W
-            elif configured_unit != "w":
-                 logger.warning(f"Unsupported unit '{configured_unit}' configured for entity '{entity_id_for_log}'. Assuming Watts.")
-
-            return Watts(value)
-        except (ValueError, TypeError) as e:
-            logger.error(f"Could not parse power value for entity '{entity_id_for_log}' from state='{state}': {e}")
-            return None
-
-
-    def _parse_percentage(self, state: Optional[str], entity_id_for_log: str) -> Optional[Percentage]:
-        """Parses state string to Percentage, handling errors."""
-        if state is None:
-            return None
-        try:
-            value = float(state)
-            if math.isnan(value):
-                logger.warning(f"Parsed NaN value for entity '{entity_id_for_log}', state='{state}'. Treating as missing.")
-                return None
-            return Percentage(max(0.0, min(100.0, value))) # Clamp between 0 and 100
-        except (ValueError, TypeError) as e:
-            logger.error(f"Could not parse percentage value for entity '{entity_id_for_log}' from state='{state}': {e}")
-            return None
-
+            self.logger.debug(f"Static Battery Capacity: {self.battery_capacity} Wh")
 
     def get_current_energy_state(self) -> Optional[EnergyStateSnapshot]:
-        logger.debug("Fetching current energy state from Home Assistant...")
+        self.logger.debug("Fetching current energy state from Home Assistant...")
         now = Timestamp(datetime.now())
         has_critical_error = False
 
@@ -183,14 +99,14 @@ class HomeAssistantEnergyMonitor(EnergyMonitorPort):
 
         # Check if essential values are missing
         if production_watts is None and self.entity_solar:
-             logger.error(f"Missing critical value: Solar Production (Entity: {self.entity_solar})")
-             has_critical_error = True
+            self.logger.error(f"Missing critical value: Solar Production (Entity: {self.entity_solar})")
+            has_critical_error = True
         if consumption_watts is None and self.entity_consumption:
-             logger.error(f"Missing critical value: House Consumption (Entity: {self.entity_consumption})")
-             has_critical_error = True
+            self.logger.error(f"Missing critical value: House Consumption (Entity: {self.entity_consumption})")
+            self.has_critical_error = True
 
         if has_critical_error:
-            logger.error("Failed to retrieve one or more critical energy values from Home Assistant. Cannot create snapshot.")
+            self.logger.error("Failed to retrieve one or more critical energy values from Home Assistant. Cannot create snapshot.")
             return None
 
         # Fill defaults if entities weren't configured
@@ -209,20 +125,19 @@ class HomeAssistantEnergyMonitor(EnergyMonitorPort):
                 timestamp=now
             )
         elif self.entity_battery_soc: # Log if configured but data missing
-            logger.warning("Battery SOC entity configured, but could not create full BatteryState "
-                           "(missing power or static capacity setting?).")
-
+            self.logger.warning("Battery SOC entity configured, but could not create full BatteryState (missing power or static capacity setting?).")
 
         snapshot = EnergyStateSnapshot(
             production=production_watts,
             consumption=consumption_watts,
             battery=battery_state,
-            grid_power=grid_watts,
+            grid=grid_watts,
             timestamp=now
         )
 
-        logger.info(f"HA Monitor: State fetched: Prod={snapshot.production:.0f}W, "
-                    f"Cons={snapshot.consumption:.0f}W, Grid={snapshot.grid_power:.0f}W, "
+        self.logger.info(f"HA Monitor: State fetched: Prod={snapshot.production:.0f}W, "
+                    f"Cons={snapshot.consumption:.0f}W, Grid={snapshot.grid:.0f}W, "
                     f"SOC={snapshot.battery.state_of_charge if snapshot.battery else 'N/A'}%, "
                     f"BattPwr={snapshot.battery.current_power if snapshot.battery else 'N/A'}W")
+        
         return snapshot

--- a/edge_mining/adapters/domain/forecast/dummy.py
+++ b/edge_mining/adapters/domain/forecast/dummy.py
@@ -28,19 +28,18 @@ class DummyForecastProvider(ForecastProviderPort):
             hour = future_time.hour
 
             if 6 < hour < 20:
-                 # Simple sinusoidal based on hour
-                 solar_factor = max(0, 1 - abs(hour - 13) / 7)
-                 # Add some randomness
-                 noise = random.uniform(0.7, 1.0)
-                 predicted_power = Watts(base_max_watts * solar_factor * noise)
+                # Simple sinusoidal based on hour
+                solar_factor = max(0, 1 - abs(hour - 13) / 7)
+                # Add some randomness
+                noise = random.uniform(0.7, 1.0)
+                predicted_power = Watts(base_max_watts * solar_factor * noise)
             else:
-                 predicted_power = Watts(0.0)
+                predicted_power = Watts(0.0)
 
             predictions[Timestamp(future_time)] = predicted_power
 
         forecast = ForecastData(
-            provider="Dummy",
-            predicted_watts=predictions,
+            predicted_power=predictions,
             generated_at=Timestamp(now)
         )
         print(f"DummyForecastProvider: Generated {len(predictions)} predictions.")

--- a/edge_mining/adapters/domain/forecast/home_assistant_api.py
+++ b/edge_mining/adapters/domain/forecast/home_assistant_api.py
@@ -1,0 +1,147 @@
+"""Home Assistant API adapter (Implementation of Port) for the energy forecast of Edge Mining Application"""
+
+from typing import Optional, Dict, Tuple
+from datetime import datetime, timedelta
+
+from edge_mining.domain.forecast.ports import ForecastProviderPort
+from edge_mining.shared.logging.port import LoggerPort
+from edge_mining.domain.common import Watts, WattHours, Timestamp
+from edge_mining.domain.forecast.value_objects import ForecastData
+
+from edge_mining.adapters.infrastructure.homeassistant.homeassistant_api import ServiceHomeAssistantAPI
+
+class HomeAssistantForecastProvider(ForecastProviderPort):
+    """
+    Fetches energy forecast from a Home Assistant instance via its REST API.
+
+    Requires careful configuration of entity IDs in the .env file.
+    """
+    def __init__(
+        self,
+        home_assistant: ServiceHomeAssistantAPI,
+        entity_solar_forecast_power_actual_h: Optional[str],
+        entity_solar_forecast_power_next_1h: Optional[str],
+        entity_solar_forecast_power_next_12h: Optional[str],
+        entity_solar_forecast_power_next_24h: Optional[str],
+        entity_solar_forecast_energy_actual_h: Optional[str],
+        entity_solar_forecast_energy_next_1h: Optional[str],
+        entity_solar_forecast_energy_next_24h: Optional[str],
+        entity_solar_forecast_energy_remaining_today: Optional[str],
+        unit_solar_forecast_power_actual_h: str = "W",
+        unit_solar_forecast_power_next_1h: str = "W",
+        unit_solar_forecast_power_next_12h: str = "W",
+        unit_solar_forecast_power_next_24h: str = "W",
+        unit_solar_forecast_energy_actual_h: str = "kWh",
+        unit_solar_forecast_energy_next_1h: str = "kWh",
+        unit_solar_forecast_energy_next_24h: str = "kWh",
+        unit_solar_forecast_energy_remaining_today: str = "kWh",
+        logger: LoggerPort = None
+    ):
+         # Initialize the HomeAssistant API Service
+        self.home_assistant = home_assistant
+        self.logger = logger
+
+        self.entity_solar_forecast_power_actual_h = entity_solar_forecast_power_actual_h
+        self.entity_solar_forecast_power_next_1h = entity_solar_forecast_power_next_1h
+        self.entity_solar_forecast_power_next_12h = entity_solar_forecast_power_next_12h
+        self.entity_solar_forecast_power_next_24h = entity_solar_forecast_power_next_24h
+        self.entity_solar_forecast_energy_actual_h = entity_solar_forecast_energy_actual_h
+        self.entity_solar_forecast_energy_next_1h = entity_solar_forecast_energy_next_1h
+        self.entity_solar_forecast_energy_next_24h = entity_solar_forecast_energy_next_24h
+        self.entity_solar_forecast_energy_remaining_today = entity_solar_forecast_energy_remaining_today
+        self.unit_solar_forecast_power_actual_h = unit_solar_forecast_power_actual_h.lower()
+        self.unit_solar_forecast_power_next_1h = unit_solar_forecast_power_next_1h.lower()
+        self.unit_solar_forecast_power_next_12h = unit_solar_forecast_power_next_12h.lower()
+        self.unit_solar_forecast_power_next_24h = unit_solar_forecast_power_next_24h.lower()
+        self.unit_solar_forecast_energy_actual_h = unit_solar_forecast_energy_actual_h.lower()
+        self.unit_solar_forecast_energy_next_1h = unit_solar_forecast_energy_next_1h.lower()
+        self.unit_solar_forecast_energy_next_24h = unit_solar_forecast_energy_next_24h.lower()
+        self.unit_solar_forecast_energy_remaining_today = unit_solar_forecast_energy_remaining_today.lower()
+
+        self.logger.debug(f"Entities Configured for Power:"
+                    f"Actual='{entity_solar_forecast_power_actual_h}', Next 1h='{entity_solar_forecast_power_next_1h}', "
+                    f"Next 12h='{entity_solar_forecast_power_next_12h}', Next 24h='{entity_solar_forecast_power_next_24h}'")
+        self.logger.debug(f"Entities Configured for Energy:"
+                    f"Actual='{entity_solar_forecast_energy_actual_h}', Next 1h='{entity_solar_forecast_energy_next_1h}', "
+                    f"Next 24h='{entity_solar_forecast_energy_next_24h}', Remaining='{entity_solar_forecast_energy_remaining_today}'")
+        
+        self.logger.debug(f"Units for Power:"
+                    f"Actual='{unit_solar_forecast_power_actual_h}', Next 1h='{unit_solar_forecast_power_next_1h}', "
+                    f"Next 12h='{unit_solar_forecast_power_next_12h}', Next 24h='{unit_solar_forecast_power_next_24h}'")
+        self.logger.debug(f"Units Configured for Energy:"
+                    f"Actual='{unit_solar_forecast_energy_actual_h}', Next 1h='{unit_solar_forecast_energy_next_1h}', "
+                    f"Next 24h='{unit_solar_forecast_energy_next_24h}', Remaining='{unit_solar_forecast_energy_remaining_today}'")
+    
+    def get_solar_forecast(self) -> Optional[ForecastData]:
+        """Fetches the solar energy production forecast."""
+        self.logger.debug("Fetching solar forecast energy state from Home Assistant...")
+        now = Timestamp(datetime.now())
+        has_critical_error = False
+
+        # Fetch states from Home Assistant
+        state_solar_forecast_power_actual_h, _ = self.home_assistant.get_entity_state(self.entity_solar_forecast_power_actual_h)
+        state_solar_forecast_power_next_1h, _ = self.home_assistant.get_entity_state(self.entity_solar_forecast_power_next_1h)
+        state_solar_forecast_power_next_12h, _ = self.home_assistant.get_entity_state(self.entity_solar_forecast_power_next_12h)
+        state_solar_forecast_power_next_24h, _ = self.home_assistant.get_entity_state(self.entity_solar_forecast_power_next_24h)
+        state_solar_forecast_energy_actual_h, _ = self.home_assistant.get_entity_state(self.entity_solar_forecast_energy_actual_h)
+        state_solar_forecast_energy_next_1h, _ = self.home_assistant.get_entity_state(self.entity_solar_forecast_energy_next_1h)
+        state_solar_forecast_energy_next_24h, _ = self.home_assistant.get_entity_state(self.entity_solar_forecast_energy_next_24h)
+        state_solar_forecast_energy_remaining_today, _ = self.home_assistant.get_entity_state(self.entity_solar_forecast_energy_remaining_today)
+
+        # Parse values, converting units and handling errors
+        power_actual_h = self.home_assistant.parse_power(state_solar_forecast_power_actual_h, self.unit_solar_forecast_power_actual_h, self.entity_solar_forecast_power_actual_h or "N/A")
+        power_next_1h = self.home_assistant.parse_power(state_solar_forecast_power_next_1h, self.unit_solar_forecast_power_next_1h, self.entity_solar_forecast_power_next_1h or "N/A")
+        power_next_12h = self.home_assistant.parse_power(state_solar_forecast_power_next_12h, self.unit_solar_forecast_power_next_12h, self.entity_solar_forecast_power_next_12h or "N/A")
+        power_next_24h = self.home_assistant.parse_power(state_solar_forecast_power_next_24h, self.unit_solar_forecast_power_next_24h, self.entity_solar_forecast_power_next_24h or "N/A")
+        energy_actual_h = self.home_assistant.parse_energy(state_solar_forecast_energy_actual_h, self.unit_solar_forecast_energy_actual_h, self.entity_solar_forecast_energy_actual_h or "N/A")
+        energy_next_1h = self.home_assistant.parse_energy(state_solar_forecast_energy_next_1h, self.unit_solar_forecast_energy_next_1h, self.entity_solar_forecast_energy_next_1h or "N/A")
+        energy_next_24h = self.home_assistant.parse_energy(state_solar_forecast_energy_next_24h, self.unit_solar_forecast_energy_next_24h, self.entity_solar_forecast_energy_next_24h or "N/A")
+        energy_remaining_today = self.home_assistant.parse_energy(state_solar_forecast_energy_remaining_today, self.unit_solar_forecast_energy_remaining_today, self.entity_solar_forecast_energy_remaining_today or "N/A")
+
+        # Check if essential values are missing
+        if energy_next_24h is None and self.entity_solar_forecast_energy_next_24h:
+            self.logger.error(f"Missing critical value: Solar Production (Entity: {self.entity_solar_forecast_energy_next_24h})")
+            has_critical_error = True
+        
+        # Add here other checks for critical values as needed
+        
+        if has_critical_error:
+            self.logger.error("Failed to retrieve one or more critical energy values from Home Assistant. Cannot create forecast data.")
+            return None
+
+        now = datetime.now()
+        
+        # Add power data
+        power_predictions: Dict[Timestamp, Watts] = {}
+        
+        if power_actual_h is not None:
+            power_predictions[(now, now + timedelta(hours=0))] = power_actual_h
+        if power_next_1h is not None:
+            power_predictions[(now, now + timedelta(hours=1))] = power_next_1h
+        if power_next_12h is not None:    
+            power_predictions[(now, now + timedelta(hours=12))] = power_next_12h
+        if power_next_24h is not None:
+            power_predictions[(now, now + timedelta(hours=24))] = power_next_24h
+
+        # Add energy data
+        energy_predictions: Dict[Tuple[Timestamp, Timestamp], WattHours] = {}
+        
+        if energy_actual_h is not None:
+            energy_predictions[(now, now + timedelta(hours=0))] = energy_actual_h
+        if energy_next_1h is not None:
+            energy_predictions[(now, now + timedelta(hours=1))] = energy_next_1h
+        if energy_remaining_today is not None:
+            energy_predictions[(now, now + timedelta(hours=24))] = energy_remaining_today
+        
+        energy_predictions[(now, now + timedelta(hours=24))] = energy_next_24h
+        
+        forecast = ForecastData(
+            predicted_energy=energy_predictions,
+            predicted_power=power_predictions,
+            generated_at=now
+        )
+
+        self.logger.info(f"HA Monitor: Forecast Power State fetched: {forecast.predicted_power}")
+        self.logger.info(f"HA Monitor: Forecast Energy State fetched: {forecast.predicted_energy}")
+        
+        return forecast

--- a/edge_mining/adapters/domain/home_load/repositories.py
+++ b/edge_mining/adapters/domain/home_load/repositories.py
@@ -56,7 +56,7 @@ class SqliteHomeLoadsProfileRepository(BaseSqliteRepository, HomeLoadsProfileRep
                 devices=devices
             )
         except (json.JSONDecodeError, ValueError, KeyError, TypeError) as e:
-            self.logger.error(f"Error deserializing HomeLoadsProfile from DB line: {dict(row)}. Error: {e}", exc_info=True)
+            self.logger.error(f"Error deserializing HomeLoadsProfile from DB line: {dict(row)}. Error: {e}")
             return None
 
 

--- a/edge_mining/adapters/domain/miner/dummy.py
+++ b/edge_mining/adapters/domain/miner/dummy.py
@@ -7,6 +7,7 @@ import random
 from edge_mining.domain.common import Watts
 from edge_mining.domain.miner.ports import MinerControlPort
 from edge_mining.domain.miner.common import MinerId, MinerStatus
+from edge_mining.domain.miner.value_objects import HashRate
 
 class DummyMinerController(MinerControlPort):
     """Simulates miner control without real hardware."""
@@ -16,7 +17,7 @@ class DummyMinerController(MinerControlPort):
 
     def _ensure_miner(self, miner_id: MinerId):
         if miner_id not in self._status:
-             self._status[miner_id] = MinerStatus.UNKNOWN # Default if never seen
+            self._status[miner_id] = MinerStatus.UNKNOWN # Default if never seen
 
     def start_miner(self, miner_id: MinerId) -> bool:
         self._ensure_miner(miner_id)
@@ -37,8 +38,8 @@ class DummyMinerController(MinerControlPort):
         if self._status[miner_id] == MinerStatus.ON:
             self._status[miner_id] = MinerStatus.STOPPING
             print(f"DummyController: Setting {miner_id} status to STOPPING")
-             # Simulate transition
-             # threading.Timer(3, self._set_status, args=(miner_id, MinerStatus.OFF)).start()
+            # Simulate transition
+            # threading.Timer(3, self._set_status, args=(miner_id, MinerStatus.OFF)).start()
         return True # Assume command sent successfully
 
     def get_miner_status(self, miner_id: MinerId) -> MinerStatus:
@@ -70,12 +71,24 @@ class DummyMinerController(MinerControlPort):
             print(f"DummyController: Reporting power {power:.0f}W for {miner_id}")
             return power
         elif status == MinerStatus.STARTING:
-             power = Watts(self._power * random.uniform(0.3, 0.7)) # Lower power during startup
-             print(f"DummyController: Reporting power {power:.0f}W for {miner_id}")
-             return power
+            power = Watts(self._power * random.uniform(0.3, 0.7)) # Lower power during startup
+            print(f"DummyController: Reporting power {power:.0f}W for {miner_id}")
+            return power
         else:
             print(f"DummyController: Reporting power 0W for {miner_id} (status: {status.name})")
             return Watts(0.0)
+    
+    def get_miner_hashrate(self, miner_id: MinerId) -> Optional[HashRate]:
+        self._ensure_miner(miner_id)
+        status = self._status.get(miner_id)
+        if status == MinerStatus.ON:
+            # Simulate hash rate
+            hash_rate = HashRate(value=random.uniform(20, 100), unit="TH/s")
+            print(f"DummyController: Reporting hash rate {hash_rate.value:.2f} {hash_rate.unit} for {miner_id}")
+            return hash_rate
+        else:
+            print(f"DummyController: Reporting hash rate 0 for {miner_id} (status: {status.name})")
+            return HashRate(value=0.0, unit="TH/s")
 
     # Helper for simulated transitions (if using timers)
     # def _set_status(self, miner_id: MinerId, status: MinerStatus):

--- a/edge_mining/adapters/domain/miner/fast_api/router.py
+++ b/edge_mining/adapters/domain/miner/fast_api/router.py
@@ -8,7 +8,9 @@ from edge_mining.application.services.configuration_service import Configuration
 from edge_mining.domain.miner.common import MinerId
 from edge_mining.domain.exceptions import MinerNotFoundError
 
-from edge_mining.adapters.domain.miner.fast_api.schemas import MinerSchema
+from edge_mining.adapters.domain.miner.fast_api.schemas import (
+    MinerResponseSchema, MinerCreateSchema, MinerUpdateSchema
+)
 
 # Import the dependency injection function defined in main_api.py
 from edge_mining.adapters.infrastructure.api.main_api import get_config_service
@@ -16,7 +18,7 @@ from edge_mining.adapters.infrastructure.api.main_api import get_config_service
 router = APIRouter()
 
 
-@router.get("/miners", response_model=List[MinerSchema]) # Use DTOs directly or a Pydantic schema
+@router.get("/miners", response_model=List[MinerResponseSchema]) # Use DTOs directly or a Pydantic schema
 async def get_miners_list(
     config_service: Annotated[ConfigurationService, Depends(get_config_service)]
 ):
@@ -28,7 +30,7 @@ async def get_miners_list(
         response_miners = []
         for miner in miners:
             response_miners.append(
-                MinerSchema(
+                MinerResponseSchema(
                     id=miner.id,
                     name=miner.name,
                     status=miner.status,
@@ -41,7 +43,7 @@ async def get_miners_list(
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-@router.get("/miners/{miner_id}", response_model=MinerSchema)
+@router.get("/miners/{miner_id}", response_model=MinerResponseSchema)
 async def get_miner_details(
     miner_id: MinerId,
     config_service: Annotated[ConfigurationService, Depends(get_config_service)]
@@ -52,10 +54,12 @@ async def get_miner_details(
         if miner is None:
             raise HTTPException(status_code=404, detail="Miner not found")
 
-        response = MinerSchema(
+        response = MinerResponseSchema(
             id=miner.id,
             name=miner.name,
-            ip_address=miner.ip_address
+            ip_address=miner.ip_address,
+            status=miner.status,
+            power_consumption=miner.power_consumption
         )
 
         return response
@@ -64,39 +68,82 @@ async def get_miner_details(
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-@router.post("/miners", response_model=MinerSchema)
+@router.post("/miners", response_model=MinerResponseSchema)
 async def add_miner(
-    miner: MinerSchema,
+    miner: MinerCreateSchema,
     config_service: Annotated[ConfigurationService, Depends(get_config_service)]
 ):
     """Add a new miner."""
     try:
         new_miner = config_service.add_miner(
-            miner_id=miner.id,
             name=miner.name,
-            ip_address=miner.ip_address
+            ip_address=miner.ip_address,
+            power_consumption=miner.power_consumption
         )
 
-        response = MinerSchema(
+        response = MinerResponseSchema(
             id=new_miner.id,
             name=new_miner.name,
             status=new_miner.status,
-            ip_address=new_miner.ip_address
+            ip_address=new_miner.ip_address,
+            power_consumption=new_miner.power_consumption
         )
 
         return response
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-@router.delete("/miners/{miner_id}")
+@router.delete("/miners/{miner_id}", response_model=MinerResponseSchema)
 async def remove_miner(
     miner_id: MinerId,
     config_service: Annotated[ConfigurationService, Depends(get_config_service)]
 ):
     """Remove a miner."""
     try:
-        config_service.remove_miner(miner_id)
-        return {"detail": "Miner removed successfully"}
+        deleted_miner = config_service.remove_miner(miner_id)
+        
+        response = MinerResponseSchema(
+            id=deleted_miner.id,
+            name=deleted_miner.name,
+            status=deleted_miner.status,
+            ip_address=deleted_miner.ip_address,
+            power_consumption=deleted_miner.power_consumption
+        )
+
+        return response
+    except MinerNotFoundError:
+        raise HTTPException(status_code=404, detail="Miner not found")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@router.put("/miners/{miner_id}", response_model=MinerResponseSchema)
+async def update_miner(
+    miner_id: MinerId,
+    miner_update: MinerUpdateSchema,
+    config_service: Annotated[ConfigurationService, Depends(get_config_service)]
+):
+    """Update a miner's details."""
+    try:
+        miner = config_service.get_miner(miner_id)
+        if miner is None:
+            raise HTTPException(status_code=404, detail="Miner not found")
+
+        miner_updated = config_service.update_miner(
+            miner_id=miner_id,
+            name=miner_update.name,
+            ip_address=miner_update.ip_address,
+            power_consumption=miner_update.power_consumption
+        )
+
+        response = MinerResponseSchema(
+            id=miner_updated.id,
+            name=miner_updated.name,
+            status=miner_updated.status,
+            ip_address=miner_updated.ip_address,
+            power_consumption=miner_updated.power_consumption
+        )
+
+        return response
     except MinerNotFoundError:
         raise HTTPException(status_code=404, detail="Miner not found")
     except Exception as e:

--- a/edge_mining/adapters/domain/miner/fast_api/router.py
+++ b/edge_mining/adapters/domain/miner/fast_api/router.py
@@ -51,8 +51,6 @@ async def get_miner_details(
     """Get details for a specific miner."""
     try:
         miner = config_service.get_miner(miner_id)
-        if miner is None:
-            raise HTTPException(status_code=404, detail="Miner not found")
 
         response = MinerResponseSchema(
             id=miner.id,
@@ -125,11 +123,9 @@ async def update_miner(
     """Update a miner's details."""
     try:
         miner = config_service.get_miner(miner_id)
-        if miner is None:
-            raise HTTPException(status_code=404, detail="Miner not found")
 
         miner_updated = config_service.update_miner(
-            miner_id=miner_id,
+            miner_id=miner.id,
             name=miner_update.name,
             ip_address=miner_update.ip_address,
             power_consumption=miner_update.power_consumption

--- a/edge_mining/adapters/domain/miner/fast_api/schemas.py
+++ b/edge_mining/adapters/domain/miner/fast_api/schemas.py
@@ -3,13 +3,8 @@
 from pydantic import BaseModel
 from typing import List, Optional, Annotated
 
-class MinerCreateSchema(BaseModel):
-    miner_id: str
-    name: str
-    ip_address: Optional[str] = None
-
-class MinerResponseSchema(BaseModel):
+class MinerSchema(BaseModel):
     id: str
     name: str
     ip_address: Optional[str] = None
-    status: str # Use enum name
+    power_consumption: Optional[str] = None

--- a/edge_mining/adapters/domain/miner/fast_api/schemas.py
+++ b/edge_mining/adapters/domain/miner/fast_api/schemas.py
@@ -6,5 +6,6 @@ from typing import List, Optional, Annotated
 class MinerSchema(BaseModel):
     id: str
     name: str
+    status: str
     ip_address: Optional[str] = None
     power_consumption: Optional[str] = None

--- a/edge_mining/adapters/domain/miner/fast_api/schemas.py
+++ b/edge_mining/adapters/domain/miner/fast_api/schemas.py
@@ -3,25 +3,36 @@
 from pydantic import BaseModel
 from typing import List, Optional, Annotated
 
+from edge_mining.domain.miner.value_objects import HashRate
+
 class MinerResponseSchema(BaseModel):
     id: str
     name: str
     status: str
+    active: bool
     ip_address: Optional[str] = None
-    power_consumption: Optional[str] = None
+    hash_rate: Optional[HashRate] = None
+    hash_rate_max: Optional[HashRate] = None
+    power_consumption: Optional[float] = None
+    power_consumption_max: Optional[float] = None
 
 class MinerCreateSchema(BaseModel):
     name: str
+    active: bool
     ip_address: Optional[str] = None
-    power_consumption: Optional[str] = None
+    hash_rate_max: Optional[HashRate] = None
+    power_consumption_max: Optional[float] = None
 
 class MinerUpdateSchema(BaseModel):
     name: str
-    status: str
+    active: bool
     ip_address: Optional[str] = None
-    power_consumption: Optional[str] = None
+    hash_rate_max: Optional[HashRate] = None
+    power_consumption_max: Optional[float] = None
 
 class MinerStatusSchema(BaseModel):
     id: str
     status: str
-    power_consumption: Optional[str] = None
+    active: bool
+    hash_rate: Optional[HashRate] = None
+    power_consumption: Optional[float] = None

--- a/edge_mining/adapters/domain/miner/fast_api/schemas.py
+++ b/edge_mining/adapters/domain/miner/fast_api/schemas.py
@@ -3,8 +3,19 @@
 from pydantic import BaseModel
 from typing import List, Optional, Annotated
 
-class MinerSchema(BaseModel):
+class MinerResponseSchema(BaseModel):
     id: str
+    name: str
+    status: str
+    ip_address: Optional[str] = None
+    power_consumption: Optional[str] = None
+
+class MinerCreateSchema(BaseModel):
+    name: str
+    ip_address: Optional[str] = None
+    power_consumption: Optional[str] = None
+
+class MinerUpdateSchema(BaseModel):
     name: str
     status: str
     ip_address: Optional[str] = None

--- a/edge_mining/adapters/domain/miner/fast_api/schemas.py
+++ b/edge_mining/adapters/domain/miner/fast_api/schemas.py
@@ -20,3 +20,8 @@ class MinerUpdateSchema(BaseModel):
     status: str
     ip_address: Optional[str] = None
     power_consumption: Optional[str] = None
+
+class MinerStatusSchema(BaseModel):
+    id: str
+    status: str
+    power_consumption: Optional[str] = None

--- a/edge_mining/adapters/domain/miner/repositories.py
+++ b/edge_mining/adapters/domain/miner/repositories.py
@@ -1,5 +1,6 @@
 import copy
 import sqlite3
+import uuid
 from typing import List, Optional, Dict
 
 from edge_mining.domain.common import Watts
@@ -16,6 +17,10 @@ from edge_mining.adapters.infrastructure.persistence.sqlite import BaseSqliteRep
 class InMemoryMinerRepository(MinerRepository):
     def __init__(self, initial_miners: Optional[Dict[MinerId, Miner]] = None):
         self._miners: Dict[MinerId, Miner] = copy.deepcopy(initial_miners) if initial_miners else {}
+        
+    def generate_id(self) -> MinerId:
+        """Generates a new unique ID for a miner."""
+        return MinerId(str(uuid.uuid4()))
 
     def add(self, miner: Miner) -> None:
         if miner.id in self._miners:
@@ -39,6 +44,9 @@ class InMemoryMinerRepository(MinerRepository):
             del self._miners[miner_id]
 
 class SqliteMinerRepository(BaseSqliteRepository, MinerRepository):
+    def generate_id(self) -> MinerId:
+        """Generates a new unique ID for a miner."""
+        return MinerId(str(uuid.uuid4()))
 
     def _row_to_miner(self, row: sqlite3.Row) -> Optional[Miner]:
         if not row:

--- a/edge_mining/adapters/domain/miner/repositories.py
+++ b/edge_mining/adapters/domain/miner/repositories.py
@@ -1,13 +1,15 @@
 import copy
 import sqlite3
 import uuid
-from typing import List, Optional, Dict
+import json
+from typing import List, Optional, Dict, Any
 
 from edge_mining.domain.common import Watts
 from edge_mining.domain.exceptions import MinerError
 
 from edge_mining.domain.miner.common import MinerId, MinerStatus
 from edge_mining.domain.miner.entities import Miner
+from edge_mining.domain.miner.value_objects import HashRate
 from edge_mining.domain.miner.ports import MinerRepository
 
 from edge_mining.adapters.infrastructure.persistence.sqlite import BaseSqliteRepository
@@ -24,8 +26,8 @@ class InMemoryMinerRepository(MinerRepository):
 
     def add(self, miner: Miner) -> None:
         if miner.id in self._miners:
-             # Handle update or raise error depending on desired behavior
-             print(f"Warning: Miner {miner.id} already exists, overwriting.")
+            # Handle update or raise error depending on desired behavior
+            print(f"Warning: Miner {miner.id} already exists, overwriting.")
         self._miners[miner.id] = copy.deepcopy(miner)
 
     def get_by_id(self, miner_id: MinerId) -> Optional[Miner]:
@@ -47,17 +49,42 @@ class SqliteMinerRepository(BaseSqliteRepository, MinerRepository):
     def generate_id(self) -> MinerId:
         """Generates a new unique ID for a miner."""
         return MinerId(str(uuid.uuid4()))
+    
+    def _dict_to_hashrate(self, data: Dict[str, Any]) -> HashRate:
+        # Deserialize a dictionary (from JSON) into an HashRate object
+        return HashRate(
+            value=float(data['value']),
+            unit=data['unit']
+        )
+
+    def _hashrate_to_dict(self, hash_rate: HashRate) -> Dict[str, Any]:
+        # Serializes an HashRate object into a dictionary for JSON
+        return {
+            'value': hash_rate.value,
+            'unit': hash_rate.unit
+        }
 
     def _row_to_miner(self, row: sqlite3.Row) -> Optional[Miner]:
         if not row:
             return None
         try:
+            # Deserialize hash_rate from the database row
+            hash_rate_data = json.loads(row["hash_rate"]) if row["hash_rate"] else None
+            hash_rate_max_data = json.loads(row["hash_rate_max"]) if row["hash_rate_max"] else None
+            
+            hash_rate = self._dict_to_hashrate(hash_rate_data) if hash_rate_data else None
+            hash_rate_max = self._dict_to_hashrate(hash_rate_max_data) if hash_rate_max_data else None
+            
             return Miner(
                 id=MinerId(row["id"]),
-                name=row["name"],
-                ip_address=row["ip_address"],
+                name=row["name"] if row["name"] is not None else "",
+                ip_address=row["ip_address"] if row["ip_address"] is not None else "",
                 status=MinerStatus(row["status"]),
-                power_consumption=Watts(row["power_consumption"]) if row["power_consumption"] is not None else None
+                active=row["active"] == 1 if row["active"] is not None else False,
+                hash_rate=hash_rate,
+                hash_rate_max=hash_rate_max,
+                power_consumption=Watts(row["power_consumption"]) if row["power_consumption"] is not None else None,
+                power_consumption_max=Watts(row["power_consumption_max"]) if row["power_consumption_max"] is not None else None
             )
         except (ValueError, KeyError) as e:
             self.logger.error(f"Error deserializing Miner from DB row: {row}. Errorr: {e}")
@@ -67,23 +94,31 @@ class SqliteMinerRepository(BaseSqliteRepository, MinerRepository):
         self.logger.debug(f"Adding miner {miner.id} to SQLite.")
         
         sql = """
-            INSERT INTO miners (id, name, ip_address, status, power_consumption)
-            VALUES (?, ?, ?, ?, ?)
+            INSERT INTO miners (id, name, ip_address, status, active, hash_rate, hash_rate_max power_consumption, power_consumption_max)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
         """
         conn = self._get_connection()
         try:
+            # Serialize hash_rate to JSON for storage
+            hash_rate_json = json.dumps(self._hashrate_to_dict(miner.hash_rate))
+            hash_rate_max_json = json.dumps(self._hashrate_to_dict(miner.hash_rate_max))
+            
             with conn:
                 conn.execute(sql, (
                     miner.id,
                     miner.name,
                     miner.ip_address,
                     miner.status.value,
-                    float(miner.power_consumption) if miner.power_consumption is not None else None
+                    miner.active,
+                    hash_rate_json,
+                    hash_rate_max_json,
+                    float(miner.power_consumption) if miner.power_consumption is not None else None,
+                    float(miner.power_consumption_max) if miner.power_consumption_max is not None else None
                 ))
         except sqlite3.IntegrityError as e:
-             self.logger.error(f"Integrity error adding miner {miner.id}: {e}")
-             # Potrebbe significare che l'ID esiste già
-             raise MinerError(f"Miner with ID {miner.id} already exists or constraint violation: {e}") from e
+            self.logger.error(f"Integrity error adding miner {miner.id}: {e}")
+            # Potrebbe significare che l'ID esiste già
+            raise MinerError(f"Miner with ID {miner.id} already exists or constraint violation: {e}") from e
         except sqlite3.Error as e:
             self.logger.error(f"SQLite error adding miner {miner.id}: {e}")
             raise MinerError(f"DB error adding miner: {e}") from e
@@ -104,7 +139,7 @@ class SqliteMinerRepository(BaseSqliteRepository, MinerRepository):
             self.logger.error(f"SQLite error getting miner {miner_id}: {e}")
             return None # Or raise exception? Returning None is more forgiving
         finally:
-             if conn: conn.close()
+            if conn: conn.close()
 
     def get_all(self) -> List[Miner]:
         self.logger.debug("Getting all miners from SQLite.")
@@ -117,9 +152,9 @@ class SqliteMinerRepository(BaseSqliteRepository, MinerRepository):
             cursor.execute(sql)
             rows = cursor.fetchall()
             for row in rows:
-                 miner = self._row_to_miner(row)
-                 if miner:
-                     miners.append(miner)
+                miner = self._row_to_miner(row)
+                if miner:
+                    miners.append(miner)
             return miners
         except sqlite3.Error as e:
             self.logger.error(f"SQLite error getting all miners: {e}")
@@ -132,18 +167,26 @@ class SqliteMinerRepository(BaseSqliteRepository, MinerRepository):
         
         sql = """
             UPDATE miners
-            SET name = ?, ip_address = ?, status = ?, power_consumption = ?
+            SET name = ?, ip_address = ?, status = ?, active = ?, hash_rate = ?, hash_rate_max = ? power_consumption = ?, power_consumption_max = ?
             WHERE id = ?
         """
         conn = self._get_connection()
         try:
+            # Serialize hash_rate to JSON for storage
+            hash_rate_json = json.dumps(self._hashrate_to_dict(miner.hash_rate))
+            hash_rate_max_json = json.dumps(self._hashrate_to_dict(miner.hash_rate_max))
+            
             with conn:
                 cursor = conn.cursor()
                 cursor.execute(sql, (
                     miner.name,
                     miner.ip_address,
                     miner.status.value,
+                    miner.active,
+                    hash_rate_json,
+                    hash_rate_max_json,
                     float(miner.power_consumption) if miner.power_consumption is not None else None,
+                    float(miner.power_consumption_max) if miner.power_consumption_max is not None else None,
                     miner.id
                 ))
                 if cursor.rowcount == 0:

--- a/edge_mining/adapters/domain/notification/telegram.py
+++ b/edge_mining/adapters/domain/notification/telegram.py
@@ -80,5 +80,5 @@ class TelegramNotifier(NotificationPort):
             return False
         except Exception as e:
             # Gestisce altri errori (es. rete)
-            self.logger.error(f"Unexpected error sending notification via Telegram: {e}", exc_info=True)
+            self.logger.error(f"Unexpected error sending notification via Telegram: {e}")
             return False

--- a/edge_mining/adapters/domain/policy/repositories.py
+++ b/edge_mining/adapters/domain/policy/repositories.py
@@ -89,7 +89,7 @@ class SqliteOptimizationPolicyRepository(BaseSqliteRepository, OptimizationPolic
                 target_miner_ids=target_ids
             )
         except (json.JSONDecodeError, ValueError, KeyError, TypeError) as e:
-            self.logger.error(f"Error deserializing Policy from DB line: {dict(row)}. Error: {e}", exc_info=True)
+            self.logger.error(f"Error deserializing Policy from DB line: {dict(row)}. Error: {e}")
             return None
 
     def add(self, policy: OptimizationPolicy) -> None:

--- a/edge_mining/adapters/domain/user/repositories.py
+++ b/edge_mining/adapters/domain/user/repositories.py
@@ -23,7 +23,7 @@ class InMemorySettingsRepository(SettingsRepository):
         self._settings = copy.deepcopy(settings)
 
 class SqliteSettingsRepository(BaseSqliteRepository, SettingsRepository):
-    _SETTINGS_ID = "global_settings" # ID fisso per l'unica riga di settings
+    _SETTINGS_ID = "global_settings" # We dont have different users, so we use a single ID.
 
     def get_settings(self) -> Optional[SystemSettings]:
         self.logger.debug("Getting settings from SQLite.")

--- a/edge_mining/adapters/infrastructure/api/main_api.py
+++ b/edge_mining/adapters/infrastructure/api/main_api.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, Depends, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from typing import Annotated
 
 from edge_mining.application.services.configuration_service import ConfigurationService
@@ -47,6 +48,18 @@ app = FastAPI(
     title="Edge Mining API",
     description="API for managing and monitoring the bitcoin mining energy optimization system.",
     version="0.1.0"
+)
+
+# TODO: set only localhost origins
+origins = ["*"]
+
+# User CORS
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 # Include routers

--- a/edge_mining/adapters/infrastructure/api/main_api.py
+++ b/edge_mining/adapters/infrastructure/api/main_api.py
@@ -3,6 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from typing import Annotated
 
 from edge_mining.application.services.configuration_service import ConfigurationService
+from edge_mining.application.services.action_service import ActionService
 from edge_mining.application.services.mining_orchestrator import MiningOrchestratorService
 from edge_mining.shared.logging.port import LoggerPort
 
@@ -18,6 +19,11 @@ def get_config_service():
          raise RuntimeError("Config Service not initialized for API")
     return _api_config_service
 
+def get_action_service():
+    if _api_action_service is None:
+         raise RuntimeError("Action Service not initialized for API")
+    return _api_action_service
+
 def get_orchestrator_service():
     if _api_orchestrator_service is None:
          raise RuntimeError("Orchestrator Service not initialized for API")
@@ -25,15 +31,18 @@ def get_orchestrator_service():
 
 # Global placeholders - Set these during app startup
 _api_config_service: ConfigurationService = None
+_api_action_service: ActionService = None
 _api_orchestrator_service: MiningOrchestratorService = None
 
 def set_api_services(
+        action_service: ActionService,
         config_service: ConfigurationService,
         orchestrator_service: MiningOrchestratorService,
         logger: LoggerPort
     ):
-    global _api_config_service, _api_orchestrator_service, _logger
+    global _api_action_service, _api_config_service, _api_orchestrator_service, _logger
 
+    _api_action_service = action_service
     _api_config_service = config_service
     _api_orchestrator_service = orchestrator_service
     _logger = logger

--- a/edge_mining/adapters/infrastructure/cli/commands.py
+++ b/edge_mining/adapters/infrastructure/cli/commands.py
@@ -2,23 +2,27 @@
 
 import click
 
+from edge_mining.application.services.action_service import ActionService
 from edge_mining.application.services.configuration_service import ConfigurationService
 from edge_mining.application.services.mining_orchestrator import MiningOrchestratorService
 from edge_mining.shared.logging.port import LoggerPort
 
 # --- Simple way for Dependency Injection using global objects ---
+_action_service: ActionService = None
 _config_service: ConfigurationService = None
 _orchestrator_service: MiningOrchestratorService = None
 _logger: LoggerPort = None
 
 def set_cli_services(
-        config_service: ConfigurationService,
-        orchestrator_service: MiningOrchestratorService,
-        logger: LoggerPort
-    ):
-    
-    global _config_service, _orchestrator_service, _logger
-    
+    action_service: ActionService,
+    config_service: ConfigurationService,
+    orchestrator_service: MiningOrchestratorService,
+    logger: LoggerPort
+):
+
+    global _action_service, _config_service, _orchestrator_service, _logger
+
+    _action_service = action_service
     _config_service = config_service
     _orchestrator_service = orchestrator_service
     _logger = logger

--- a/edge_mining/adapters/infrastructure/cli/commands.py
+++ b/edge_mining/adapters/infrastructure/cli/commands.py
@@ -39,16 +39,15 @@ def miner():
     pass
 
 @miner.command("add")
-@click.argument("miner_id")
 @click.argument("name")
 @click.option("--ip", help="IP Address of the miner")
-def add_miner(miner_id, name, ip):
+def add_miner(name, ip):
     """Add a new miner to the system."""
     if not _config_service:
         click.echo("Error: Services not initialized.", err=True)
         return
     try:
-        added = _config_service.add_miner(miner_id=miner_id, name=name, ip_address=ip)
+        added = _config_service.add_miner(name=name, ip_address=ip)
         click.echo(f"Miner '{added.name}' ({added.id}) added successfully.")
     except Exception as e:
         click.echo(f"Error adding miner: {e}", err=True)
@@ -68,7 +67,7 @@ def list_miners():
     click.echo("Configured Miners:")
     for m in miners:
         ip_str = f" (IP: {m.ip_address})" if m.ip_address else ""
-        click.echo(f"- ID: {m.id}, Name: {m.name}{ip_str}, Status: {m.status.name}")
+        click.echo(f"- ID: {m.id}, Name: {m.name}, IP: {ip_str}, Status: {m.status.name}, Power: {m.power_consumption}W")
 
 
 @miner.command("remove")

--- a/edge_mining/adapters/infrastructure/homeassistant/homeassistant_api.py
+++ b/edge_mining/adapters/infrastructure/homeassistant/homeassistant_api.py
@@ -1,0 +1,116 @@
+"""The Home Assistant API Infrastructure adapter"""
+
+"""
+The REST API for Home Assistant has been superseded by the websocket API.
+I use it only for simplicity, in the future I plan to switch to websocket API
+
+https://github.com/home-assistant/architecture/discussions/1074#discussioncomment-9196867
+
+and
+
+https://github.com/home-assistant/developers.home-assistant/pull/2150
+"""
+from typing import Optional, Tuple
+from datetime import datetime
+import math # For isnan
+
+from edge_mining.shared.external_service.port import ExternalServicePort
+from edge_mining.shared.logging.port import LoggerPort
+
+from edge_mining.domain.common import Watts, Percentage, Timestamp
+
+try:
+    from homeassistant_api import Client
+except ImportError:
+    raise ImportError("Please install 'homeassistant_api' (`pip install homeassistant_api`) to use the Home Assistant API Infrastructure.")
+
+class BaseHomeAssistantAPI(ExternalServicePort):
+    """
+    Use Home Assistant instance via its REST API as external service.
+
+    Requires careful configuration of HA parameters in the .env file.
+    """
+    def __init__(self, api_url: str, token: str, logger: LoggerPort):
+        self.logger = logger
+        
+        if not api_url or not token:
+            raise ValueError("Home Assistant URL and Token are required.")
+        
+        self.api_url = f"{api_url}/api"
+        self.token = token
+
+        self.connect() # Connect to the API during initialization
+
+    def connect(self) -> None:
+        """Connect to the Home Assistant API."""
+        self.logger.info(f"Initializing HomeAssistantAPI for {self.api_url}")
+
+        # Initialize Home Assistant client
+        try:
+            self.client = Client(self.api_url, self.token)
+            
+            # Test connection during initialization (optional but recommended)
+            self.client.get_config()
+            self.logger.info("Successfully connected to Home Assistant API.")
+        except Exception as e:
+            self.logger.error(f"An unexpected error occurred connecting to Home Assistant: {e}")
+            raise ConnectionError(f"Unexpected error connecting to Home Assistant: {e}") from e
+    
+    def disconnect(self) -> None:
+        """Disconnect from the Home Assistant API."""
+        self.logger.info("Disconnecting from Home Assistant API.")
+        
+        # The Client does not have a disconnect method, but we can clear the client
+        self.client = None
+
+    def _get_entity_state(self, entity_id: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
+        """Safely retrieves the state and unit of an entity."""
+        if not entity_id:
+            return None, None
+        try:
+            entity = self.client.get_entity(entity_id=entity_id)
+            # Check if state is unavailable or unknown
+            state = entity.state.state # The actual value as a string
+            if state is None or state.lower() in ["unavailable", "unknown"]:
+                self.logger.warning(f"Home Assistant entity '{entity_id}' is unavailable or unknown.")
+                return None, None
+
+            unit = entity.state.attributes.get("unit_of_measurement")
+            self.logger.debug(f"Fetched HA entity '{entity_id}': State='{state}', Unit='{unit}'")
+            return state, unit
+        except Exception as e:
+            self.logger.error(f"Unexpected error getting Home Assistant entity '{entity_id}': {e}")
+            return None, None
+
+    def _parse_power(self, state: Optional[str], configured_unit: str, entity_id_for_log: str) -> Optional[Watts]:
+        """Parses state string to Watts, handling units (W/kW) and errors."""
+        if state is None:
+            return None
+        try:
+            value = float(state)
+            if math.isnan(value):
+                self.logger.warning(f"Parsed NaN value for entity '{entity_id_for_log}', state='{state}'. Treating as missing.")
+                return None
+            if configured_unit == "kw":
+                value *= 1000 # Convert kW to W
+            elif configured_unit != "w":
+                self.logger.warning(f"Unsupported unit '{configured_unit}' configured for entity '{entity_id_for_log}'. Assuming Watts.")
+
+            return Watts(value)
+        except (ValueError, TypeError) as e:
+            self.logger.error(f"Could not parse power value for entity '{entity_id_for_log}' from state='{state}': {e}")
+            return None
+
+    def _parse_percentage(self, state: Optional[str], entity_id_for_log: str) -> Optional[Percentage]:
+        """Parses state string to Percentage, handling errors."""
+        if state is None:
+            return None
+        try:
+            value = float(state)
+            if math.isnan(value):
+                self.logger.warning(f"Parsed NaN value for entity '{entity_id_for_log}', state='{state}'. Treating as missing.")
+                return None
+            return Percentage(max(0.0, min(100.0, value))) # Clamp between 0 and 100
+        except (ValueError, TypeError) as e:
+            self.logger.error(f"Could not parse percentage value for entity '{entity_id_for_log}' from state='{state}': {e}")
+            return None

--- a/edge_mining/adapters/infrastructure/logging/terminal_logging.py
+++ b/edge_mining/adapters/infrastructure/logging/terminal_logging.py
@@ -102,7 +102,7 @@ class TerminalLogger(LoggerPort):
             print(f.read())
         print("\n\n")
 
-        print("Hey! 👋 I'm Edge Mining. Let's put that wasted energy to good use and generate some satoshis ⚡⛏️")
+        print("Hey! 👋 I'm Edge Mining. Mine your energy! ⚡⛏️")
         print("\n\n")
 
     def shutdown(self):

--- a/edge_mining/adapters/infrastructure/persistence/sqlite.py
+++ b/edge_mining/adapters/infrastructure/persistence/sqlite.py
@@ -46,7 +46,11 @@ class BaseSqliteRepository:
                 name TEXT NOT NULL,
                 ip_address TEXT,
                 status TEXT NOT NULL,
-                power_consumption REAL
+                active INTEGER NOT NULL DEFAULT 1 CHECK(active IN (0,1)),
+                hash_rate TEXT, -- JSON object of HashRate dict
+                hash_rate_max TEXT, -- JSON object of HashRate dict
+                power_consumption REAL,
+                power_consumption_max REAL
             );
             """,
             """

--- a/edge_mining/application/services/action_service.py
+++ b/edge_mining/application/services/action_service.py
@@ -1,0 +1,124 @@
+"""Action service for miners, energy, and optimizations."""
+from typing import Optional
+
+from edge_mining.domain.common import Watts
+from edge_mining.domain.miner.entities import Miner
+from edge_mining.domain.miner.common import MinerId
+from edge_mining.shared.logging.port import LoggerPort
+from edge_mining.domain.exceptions import MinerError, MinerNotFoundError
+from edge_mining.domain.notification.ports import NotificationPort
+from edge_mining.domain.miner.ports import MinerControlPort, MinerRepository
+
+class ActionService:
+    """Handles actions on miners"""
+
+    def __init__(
+        self,
+        miner_controller: MinerControlPort,
+        miner_repo: MinerRepository,
+        notifier: Optional[NotificationPort] = None,
+        logger: LoggerPort = None
+    ):
+        # Domains
+        self.miner_controller = miner_controller
+        self.miner_repo = miner_repo
+        
+        # Infrastructure
+        self.notifier = notifier
+        self.logger = logger
+    
+    def _notify(self, title: str, message: str):
+        """Sends a notification using the configured notifier."""
+        if self.notifier:
+            try:
+                self.notifier.send_notification(title, message)
+            except Exception as e:
+                if self.logger:
+                    self.logger.error(f"Failed to send notification: {e}")
+
+    # --- Miner Actions ---
+    def start_miner(self, miner_id: MinerId) -> bool:
+        """Starts the specified miner."""
+        if self.logger:
+            self.logger.info(f"Starting miner {miner_id}")
+        
+        miner: Miner = self.miner_repo.get_by_id(miner_id)
+        
+        if not miner:
+            raise MinerNotFoundError(f"Miner with ID {miner_id} not found.")
+        
+        # Update miner status from controller
+        current_status = self.miner_controller.get_miner_status(miner_id)
+        current_power = self.miner_controller.get_miner_power(miner_id)
+        miner.update_status(current_status, current_power)
+        
+        # Persist the observed state
+        self.miner_repo.update(miner)
+        
+        success = self.miner_controller.start_miner(miner.id)
+        
+        if success:
+            if self.logger:
+                self.logger.info(f"Miner {miner.id} ({miner.name}) started successfully.")
+            
+            # Update domain state
+            miner.turn_on()
+            self.miner_repo.update(miner)
+            self._notify("Edge Mining Info", f"Miner {miner.id} ({miner.name}) started.")
+        else:
+            self.logger.error(f"Failed to start miner {miner.id} ({miner.name}).")
+        
+        return success
+    
+    def stop_miner(self, miner_id: MinerId) -> bool:
+        """Stops the specified miner."""
+        if self.logger:
+            self.logger.info(f"Stopping miner {miner_id}")
+        
+        miner: Miner = self.miner_repo.get_by_id(miner_id)
+        
+        if not miner:
+            raise MinerNotFoundError(f"Miner with ID {miner_id} not found.")
+        
+        # Update miner status from controller
+        current_status = self.miner_controller.get_miner_status(miner_id)
+        current_power = self.miner_controller.get_miner_power(miner_id)
+        miner.update_status(current_status, current_power)
+        
+        # Persist the observed state
+        self.miner_repo.update(miner)
+        
+        success = self.miner_controller.stop_miner(miner.id)
+        
+        if success:
+            if self.logger:
+                self.logger.info(f"Miner {miner.id} ({miner.name}) stopped successfully.")
+            
+            # Update domain state
+            miner.turn_off()
+            self.miner_repo.update(miner)
+            self._notify("Edge Mining Info", f"Miner {miner.id} ({miner.name}) stopped.")
+        else:
+            self.logger.error(f"Failed to stop miner {miner.id} ({miner.name}).")
+        
+        return success
+    
+    def get_miner_consumption(self, miner_id: MinerId) -> Optional[Watts]:
+        """Gets the current power consumption of the specified miner."""
+        if self.logger:
+            self.logger.info(f"Getting power consumption for miner {miner_id}")
+        
+        miner: Miner = self.miner_repo.get_by_id(miner_id)
+        
+        if not miner:
+            raise MinerNotFoundError(f"Miner with ID {miner_id} not found.")
+        
+        # Update miner status from controller
+        current_status = self.miner_controller.get_miner_status(miner_id)
+        current_power = self.miner_controller.get_miner_power(miner_id)
+        miner.update_status(current_status, current_power)
+        
+        # Persist the observed state
+        self.miner_repo.update(miner)
+        
+        return current_power

--- a/edge_mining/application/services/action_service.py
+++ b/edge_mining/application/services/action_service.py
@@ -4,6 +4,7 @@ from typing import Optional
 from edge_mining.domain.common import Watts
 from edge_mining.domain.miner.entities import Miner
 from edge_mining.domain.miner.common import MinerId
+from edge_mining.domain.miner.value_objects import HashRate
 from edge_mining.shared.logging.port import LoggerPort
 from edge_mining.domain.exceptions import MinerError, MinerNotFoundError
 from edge_mining.domain.notification.ports import NotificationPort
@@ -49,8 +50,9 @@ class ActionService:
         
         # Update miner status from controller
         current_status = self.miner_controller.get_miner_status(miner_id)
+        current_hashrate = self.miner_controller.get_miner_hashrate(miner_id)
         current_power = self.miner_controller.get_miner_power(miner_id)
-        miner.update_status(current_status, current_power)
+        miner.update_status(current_status, current_hashrate, current_power)
         
         # Persist the observed state
         self.miner_repo.update(miner)
@@ -82,8 +84,9 @@ class ActionService:
         
         # Update miner status from controller
         current_status = self.miner_controller.get_miner_status(miner_id)
+        current_hashrate = self.miner_controller.get_miner_hashrate(miner_id)
         current_power = self.miner_controller.get_miner_power(miner_id)
-        miner.update_status(current_status, current_power)
+        miner.update_status(current_status, current_hashrate, current_power)
         
         # Persist the observed state
         self.miner_repo.update(miner)
@@ -122,3 +125,23 @@ class ActionService:
         self.miner_repo.update(miner)
         
         return current_power
+
+    def get_miner_hashrate(self, miner_id: MinerId) -> Optional[HashRate]:
+        """Gets the current hash rate of the specified miner."""
+        if self.logger:
+            self.logger.info(f"Getting hash rate for miner {miner_id}")
+        
+        miner: Miner = self.miner_repo.get_by_id(miner_id)
+        
+        if not miner:
+            raise MinerNotFoundError(f"Miner with ID {miner_id} not found.")
+        
+        # Update miner status from controller
+        current_status = self.miner_controller.get_miner_status(miner_id)
+        current_hashrate = self.miner_controller.get_miner_hashrate(miner_id)
+        miner.update_status(current_status, current_hashrate)
+        
+        # Persist the observed state
+        self.miner_repo.update(miner)
+        
+        return current_hashrate

--- a/edge_mining/application/services/configuration_service.py
+++ b/edge_mining/application/services/configuration_service.py
@@ -49,15 +49,33 @@ class ConfigurationService:
     def list_miners(self) -> List[Miner]:
         return self.miner_repo.get_all()
 
-    def remove_miner(self, miner_id: MinerId) -> None:
+    def remove_miner(self, miner_id: MinerId) -> Miner:
         self.logger.info(f"Removing miner {miner_id}")
         
         miner: Miner = self.miner_repo.get_by_id(miner_id)
         
         if not miner:
-            raise MinerError(f"Policy with ID {miner.id} not found.")
+            raise MinerError(f"Miner with ID {miner_id} not found.")
         
         self.miner_repo.remove(miner_id)
+        
+        return miner
+    
+    def update_miner(self, miner_id: MinerId, name: str, ip_address: Optional[str] = None, power_consumption: Optional[Watts] = None) -> Miner:
+        self.logger.info(f"Updating miner {miner_id} ({name})")
+        
+        miner: Miner = self.miner_repo.get_by_id(miner_id)
+        
+        if not miner:
+            raise MinerError(f"Miner with ID {miner_id} not found.")
+        
+        miner.name = name
+        miner.ip_address = ip_address
+        miner.power_consumption = power_consumption
+        
+        self.miner_repo.update(miner)
+        
+        return miner
 
     # --- Policy Management ---
     def create_policy(self, name: str, description: str = "", target_miner_ids: List[MinerId] = None) -> OptimizationPolicy:

--- a/edge_mining/application/services/configuration_service.py
+++ b/edge_mining/application/services/configuration_service.py
@@ -1,7 +1,7 @@
 import logging
 from typing import List, Optional, Dict, Any
 
-from edge_mining.domain.common import EntityId
+from edge_mining.domain.common import EntityId, Watts
 from edge_mining.domain.miner.entities import Miner
 from edge_mining.domain.miner.common import MinerId
 from edge_mining.domain.policy.common import RuleType
@@ -32,10 +32,10 @@ class ConfigurationService:
         self.logger = logger
 
     # --- Miner Management ---
-    def add_miner(self, miner_id: MinerId, name: str, ip_address: Optional[str] = None) -> Miner:
+    def add_miner(self, miner_id: MinerId, name: str, ip_address: Optional[str] = None, power_consumption: Optional[Watts] = None) -> Miner:
         self.logger.info(f"Adding miner {miner_id} ({name})")
         
-        miner = Miner(id=miner_id, name=name, ip_address=ip_address)
+        miner = Miner(id=miner_id, name=name, ip_address=ip_address, power_consumption=power_consumption)
         
         # TODO: Add validation (e.g., check if ID already exists)
         

--- a/edge_mining/application/services/configuration_service.py
+++ b/edge_mining/application/services/configuration_service.py
@@ -1,4 +1,4 @@
-import logging
+"""Configuration service for managing miners, policies, and system settings."""
 from typing import List, Optional, Dict, Any
 
 from edge_mining.domain.common import EntityId, Watts

--- a/edge_mining/application/services/configuration_service.py
+++ b/edge_mining/application/services/configuration_service.py
@@ -32,12 +32,12 @@ class ConfigurationService:
         self.logger = logger
 
     # --- Miner Management ---
-    def add_miner(self, miner_id: MinerId, name: str, ip_address: Optional[str] = None, power_consumption: Optional[Watts] = None) -> Miner:
+    def add_miner(self, name: str, ip_address: Optional[str] = None, power_consumption: Optional[Watts] = None) -> Miner:
+        miner_id: MinerId = self.miner_repo.generate_id()
+        
         self.logger.info(f"Adding miner {miner_id} ({name})")
         
         miner = Miner(id=miner_id, name=name, ip_address=ip_address, power_consumption=power_consumption)
-        
-        # TODO: Add validation (e.g., check if ID already exists)
         
         self.miner_repo.add(miner)
         

--- a/edge_mining/application/services/configuration_service.py
+++ b/edge_mining/application/services/configuration_service.py
@@ -9,7 +9,7 @@ from edge_mining.shared.logging.port import LoggerPort
 from edge_mining.domain.miner.ports import MinerRepository
 from edge_mining.domain.user.entities import SystemSettings
 from edge_mining.domain.user.ports import SettingsRepository
-from edge_mining.domain.exceptions import PolicyError, MinerError
+from edge_mining.domain.exceptions import PolicyError, MinerError, MinerNotFoundError
 from edge_mining.domain.policy.ports import OptimizationPolicyRepository
 from edge_mining.domain.policy.aggregate_roots import OptimizationPolicy, AutomationRule, MiningDecision
 
@@ -44,7 +44,12 @@ class ConfigurationService:
         return miner
 
     def get_miner(self, miner_id: MinerId) -> Optional[Miner]:
-        return self.miner_repo.get_by_id(miner_id)
+        miner: Miner = self.miner_repo.get_by_id(miner_id)
+        
+        if not miner:
+            raise MinerNotFoundError(f"Miner with ID {miner_id} not found.")
+        
+        return miner
 
     def list_miners(self) -> List[Miner]:
         return self.miner_repo.get_all()
@@ -55,7 +60,7 @@ class ConfigurationService:
         miner: Miner = self.miner_repo.get_by_id(miner_id)
         
         if not miner:
-            raise MinerError(f"Miner with ID {miner_id} not found.")
+            raise MinerNotFoundError(f"Miner with ID {miner_id} not found.")
         
         self.miner_repo.remove(miner_id)
         
@@ -67,7 +72,7 @@ class ConfigurationService:
         miner: Miner = self.miner_repo.get_by_id(miner_id)
         
         if not miner:
-            raise MinerError(f"Miner with ID {miner_id} not found.")
+            raise MinerNotFoundError(f"Miner with ID {miner_id} not found.")
         
         miner.name = name
         miner.ip_address = ip_address

--- a/edge_mining/application/services/mining_orchestrator.py
+++ b/edge_mining/application/services/mining_orchestrator.py
@@ -36,9 +36,9 @@ class MiningOrchestratorService:
         self.home_forecast_provider = home_forecast_provider
         self.policy_repo = policy_repo
         self.miner_repo = miner_repo
-        self.notifier = notifier
         
         # Infrastructure
+        self.notifier = notifier
         self.logger = logger
 
     def _notify(self, title: str, message: str):
@@ -130,7 +130,7 @@ class MiningOrchestratorService:
                 self.logger.info(f"Executing START command for miner {miner_id}")
             success = self.miner_controller.start_miner(miner_id)
             if success:
-                 # Optimistically update status, will be confirmed next cycle
+                # Optimistically update status, will be confirmed next cycle
                 miner = self.miner_repo.get_by_id(miner_id)
                 if miner:
                     miner.turn_on() # Update domain state

--- a/edge_mining/application/services/mining_orchestrator.py
+++ b/edge_mining/application/services/mining_orchestrator.py
@@ -91,10 +91,15 @@ class MiningOrchestratorService:
 
                 # Get current *actual* status from controller, not just repo's last known state
                 current_status = self.miner_controller.get_miner_status(miner_id)
-                miner.update_status(current_status) # Update domain model state
-                # Maybe fetch power too if needed by policy and it is provided by the miner
-                # current_power = self.miner_controller.get_miner_power(miner_id)
-                # miner.update_status(current_status, current_power)
+
+                # Maybe fetch power and hashrate too if needed by policy and they are provided by the miner
+                current_power = self.miner_controller.get_miner_power(miner_id)
+                hash_rate = self.miner_controller.get_miner_hashrate(miner_id)
+                miner.update_status(
+                    new_status=current_status,
+                    hash_rate=hash_rate,
+                    power=current_power
+                )
 
                 self.miner_repo.update(miner) # Persist the observed state
 
@@ -106,7 +111,7 @@ class MiningOrchestratorService:
                     forecast=solar_forecast,
                     home_load_forecast=home_load_forecast,
                     current_miner_status=current_status,
-                    current_miner_power=None,  # Placeholder for actual power if needed
+                    current_miner_power=current_power,
                 )
 
                 self._execute_decision(miner_id, decision, current_status)

--- a/edge_mining/bootstrap.py
+++ b/edge_mining/bootstrap.py
@@ -49,7 +49,7 @@ def configure_dependencies(logger: LoggerPort, settings: AppSettings):
     logger.debug("Configuring dependencies...")
 
     # --- Persistence ---
-    if settings.persistence_adapter == PersistenceAdapter.IN_MEMORY:
+    if PersistenceAdapter(settings.persistence_adapter) == PersistenceAdapter.IN_MEMORY:
         # Pre-populate in-memory repos with some test data (used for debug or development)
         miner_repo: MinerRepository = InMemoryMinerRepository()
         policy_repo: OptimizationPolicyRepository = InMemoryOptimizationPolicyRepository()
@@ -57,7 +57,7 @@ def configure_dependencies(logger: LoggerPort, settings: AppSettings):
         home_profile_repo: HomeLoadsProfileRepository = InMemoryHomeLoadsProfileRepository()
 
         logger.debug("Using InMemory persistence adapters.")
-    elif settings.persistence_adapter == PersistenceAdapter.SQLITE:
+    elif PersistenceAdapter(settings.persistence_adapter) == PersistenceAdapter.SQLITE:
         db_path = settings.sqlite_db_file
         
         db_dir = os.path.dirname(db_path)
@@ -77,7 +77,7 @@ def configure_dependencies(logger: LoggerPort, settings: AppSettings):
         raise ValueError(f"Unsupported persistence_adapter: {settings.persistence_adapter}")
     
     # --- External Services ---
-    if ExternalServiceAdapter.HOME_ASSISTANT in [settings.energy_monitor_adapter, settings.forecast_provider_adapter]:
+    if ExternalServiceAdapter.HOME_ASSISTANT in [ExternalServiceAdapter(settings.energy_monitor_adapter), ExternalServiceAdapter(settings.forecast_provider_adapter)]:
         # Initialize Home Assistant API service
         try:
             home_assistant_api = ServiceHomeAssistantAPI(
@@ -91,14 +91,14 @@ def configure_dependencies(logger: LoggerPort, settings: AppSettings):
     
     
     # --- Energy Monitor ---
-    if settings.energy_monitor_adapter == EnergyMonitorAdapter.DUMMY:
+    if EnergyMonitorAdapter(settings.energy_monitor_adapter) == EnergyMonitorAdapter.DUMMY:
         energy_monitor: EnergyMonitorPort = DummyEnergyMonitor(
             has_battery=settings.dummy_battery_present,
             battery_capacity_wh=settings.dummy_battery_capacity_wh
         )
 
         logger.debug("Using Dummy Energy Monitor adapter.")
-    elif settings.energy_monitor_adapter == EnergyMonitorAdapter.HOME_ASSISTANT:
+    elif EnergyMonitorAdapter(settings.energy_monitor_adapter) == EnergyMonitorAdapter.HOME_ASSISTANT:
         try:
             energy_monitor: EnergyMonitorPort = HomeAssistantEnergyMonitor(
                 home_assistant=home_assistant_api,
@@ -125,7 +125,7 @@ def configure_dependencies(logger: LoggerPort, settings: AppSettings):
         raise ValueError(f"Unsupported energy_monitor_adapter: {settings.energy_monitor_adapter}")
 
     # --- Miner Controller ---
-    if settings.miner_controller_adapter == MinerControllerAdapter.DUMMY:
+    if MinerControllerAdapter(settings.miner_controller_adapter) == MinerControllerAdapter.DUMMY:
         miner_controller: MinerControlPort = DummyMinerController(
             initial_status={
                 MinerId("001"): MinerStatus.OFF,
@@ -139,7 +139,7 @@ def configure_dependencies(logger: LoggerPort, settings: AppSettings):
          raise ValueError(f"Unsupported miner_controller_adapter: {settings.miner_controller_adapter}")
 
     # --- Forecast Provider ---
-    if settings.forecast_provider_adapter == ForecastProviderAdapter.DUMMY:
+    if ForecastProviderAdapter(settings.forecast_provider_adapter) == ForecastProviderAdapter.DUMMY:
         forecast_provider: ForecastProviderPort = DummyForecastProvider(
             latitude=settings.latitude,
             longitude=settings.longitude,
@@ -147,7 +147,7 @@ def configure_dependencies(logger: LoggerPort, settings: AppSettings):
         )
 
         logger.debug("Using Dummy Forecast Provider Adapter.")
-    elif settings.forecast_provider_adapter == ForecastProviderAdapter.HOME_ASSISTANT:
+    elif ForecastProviderAdapter(settings.forecast_provider_adapter) == ForecastProviderAdapter.HOME_ASSISTANT:
         try:
             forecast_provider: ForecastProviderPort = HomeAssistantForecastProvider(
                 home_assistant=home_assistant_api,
@@ -178,7 +178,7 @@ def configure_dependencies(logger: LoggerPort, settings: AppSettings):
         raise ValueError(f"Unsupported forecast_provider_adapter: {settings.forecast_provider_adapter}")
 
     # --- Home Forecast Provider ---
-    if settings.home_forecast_adapter == HomeForecastProviderAdapter.DUMMY:
+    if HomeForecastProviderAdapter(settings.home_forecast_adapter) == HomeForecastProviderAdapter.DUMMY:
         home_forecast_provider: HomeForecastProviderPort = DummyHomeForecastProvider()
 
         logger.debug("Using Dummy Home Forecast Provider adapter.")
@@ -186,11 +186,11 @@ def configure_dependencies(logger: LoggerPort, settings: AppSettings):
         raise ValueError(f"Unsupported home_forecast_adapter: {settings.home_forecast_adapter}")
 
     # --- Notification ---
-    if settings.notification_adapter == NotificationAdapter.DUMMY:
+    if NotificationAdapter(settings.notification_adapter) == NotificationAdapter.DUMMY:
         notifier: NotificationPort = DummyNotifier()
 
         logger.debug("Using Dummy Notifier adapter.")
-    elif settings.notification_adapter == NotificationAdapter.TELEGRAM:
+    elif NotificationAdapter(settings.notification_adapter) == NotificationAdapter.TELEGRAM:
         if settings.telegram_bot_token and settings.telegram_chat_id:
             try:
                 notifier: NotificationPort = TelegramNotifier(
@@ -209,7 +209,7 @@ def configure_dependencies(logger: LoggerPort, settings: AppSettings):
         # raise ValueError(f"Unsupported notification_adapter: {settings.notification_adapter}")
 
     # --- Performance Tracker ---
-    if settings.performance_tracker_adapter == PerformaceTrackerAdapter.DUMMY:
+    if PerformaceTrackerAdapter(settings.performance_tracker_adapter) == PerformaceTrackerAdapter.DUMMY:
         perf_tracker: MiningPerformanceTrackerPort = DummyPerformanceTracker()
         
         logger.debug("Using Dummy Performance Tracker adapter.")

--- a/edge_mining/bootstrap.py
+++ b/edge_mining/bootstrap.py
@@ -37,6 +37,7 @@ from edge_mining.adapters.domain.user.repositories import InMemorySettingsReposi
 from edge_mining.shared.logging.port import LoggerPort
 from edge_mining.shared.settings.settings import AppSettings
 
+from edge_mining.application.services.action_service import ActionService
 from edge_mining.application.services.configuration_service import ConfigurationService
 from edge_mining.application.services.mining_orchestrator import MiningOrchestratorService
 
@@ -219,6 +220,14 @@ def configure_dependencies(logger: LoggerPort, settings: AppSettings):
 
     # Instantiate Application Services, injecting adapters (ports)
     logger.debug("Instantiating application services...")
+    
+    action_service = ActionService(
+        miner_controller=miner_controller,
+        miner_repo=miner_repo,
+        notifier=notifier,
+        logger=logger
+    )
+    
     config_service = ConfigurationService(
         miner_repo=miner_repo,
         policy_repo=policy_repo,
@@ -239,4 +248,4 @@ def configure_dependencies(logger: LoggerPort, settings: AppSettings):
     )
 
     logger.debug("Dependency configuration complete.")
-    return config_service, orchestrator_service
+    return action_service, config_service, orchestrator_service

--- a/edge_mining/bootstrap.py
+++ b/edge_mining/bootstrap.py
@@ -92,13 +92,14 @@ def configure_dependencies(logger: LoggerPort, settings: AppSettings):
                 unit_battery_power=settings.ha_unit_battery_power,
                 battery_capacity_wh=settings.ha_battery_nominal_capacity_wh,
                 grid_positive_export=settings.ha_grid_positive_export,
-                battery_positive_charge=settings.ha_battery_positive_charge
+                battery_positive_charge=settings.ha_battery_positive_charge,
+                logger=logger
             )
 
             logger.debug("Using Home Assistant Energy Monitor adapter.")
         except (ValueError, ConnectionError, ImportError) as e:
-             logger.error(f"Failed to initialize Home Assistant adapter: {e}")
-             raise # Raise the exception to stop the execution
+            logger.error(f"Failed to initialize Home Assistant adapter: {e}")
+            raise # Raise the exception to stop the execution
     else:
         raise ValueError(f"Unsupported energy_monitor_adapter: {settings.energy_monitor_adapter}")
 

--- a/edge_mining/domain/exceptions.py
+++ b/edge_mining/domain/exceptions.py
@@ -10,6 +10,10 @@ class MinerNotFoundError(MinerError):
     """Miner not found."""
     pass
 
+class MinerNotActiveError(MinerError):
+    """Miner not active."""
+    pass
+
 class PolicyError(DomainError):
     """Errors related to optimization policies."""
     pass

--- a/edge_mining/domain/forecast/ports.py
+++ b/edge_mining/domain/forecast/ports.py
@@ -7,6 +7,6 @@ from edge_mining.domain.forecast.value_objects import ForecastData
 
 class ForecastProviderPort(ABC):
     @abstractmethod
-    def get_solar_forecast(self, latitude: Optional[float], longitude: Optional[float], capacity_kwp: Optional[float]) -> Optional[ForecastData]:
+    def get_solar_forecast(self) -> Optional[ForecastData]:
         """Fetches the solar energy production forecast."""
         raise NotImplementedError

--- a/edge_mining/domain/forecast/value_objects.py
+++ b/edge_mining/domain/forecast/value_objects.py
@@ -1,14 +1,13 @@
 """Collection of Value Objects for the Energy Forecast domain of the Edge Mining application."""
 
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Optional, Dict, Tuple
 from datetime import datetime
 
-from edge_mining.domain.common import Watts, Timestamp, ValueObject
+from edge_mining.domain.common import Watts, WattHours, Timestamp, ValueObject
 
 @dataclass(frozen=True)
 class ForecastData(ValueObject):
-    provider: str # e.g., "HomeAssistant", "Solcast", "OpenWeatherMap"
-    # Example: Predicted power generation at specific future times
-    predicted_watts: Dict[Timestamp, Watts] = field(default_factory=dict)
+    predicted_power: Optional[Dict[Timestamp, Watts]] = field(default_factory=dict) # Predicted power generation at specific future times
+    predicted_energy: Optional[Dict[Tuple[Timestamp, Timestamp], WattHours]] = field(default_factory=dict) # Predicted energy generation at specific future time range
     generated_at: Timestamp = field(default_factory=datetime.now)

--- a/edge_mining/domain/miner/entities.py
+++ b/edge_mining/domain/miner/entities.py
@@ -4,33 +4,59 @@ from dataclasses import dataclass
 from typing import Optional
 
 from edge_mining.domain.common import Watts
+from edge_mining.domain.miner.value_objects import HashRate
 from edge_mining.domain.miner.common import MinerId, MinerStatus
+from edge_mining.domain.exceptions import MinerNotActiveError
 
 @dataclass
 class Miner:
     id: MinerId
     name: str
     status: MinerStatus = MinerStatus.UNKNOWN
+    hash_rate: Optional[HashRate] = None # Hash rate in MH/s or GH/s
+    hash_rate_max: Optional[HashRate] = None # Max hash rate for the miner
     power_consumption: Optional[Watts] = None # Can be dynamic or fixed
+    power_consumption_max: Optional[Watts] = None # Max power consumption for the miner
     ip_address: Optional[str] = None # 🤷​ Will need it for some control methods ?
-    # Potentially add more details: model, location, etc. but for now, I think this is enough
+    active: bool = True # Is the miner active in the system?
 
     def turn_on(self):
         # Domain logic: update status if applicable
-        if self.status in [MinerStatus.OFF, MinerStatus.ERROR, MinerStatus.UNKNOWN]:
-            self.status = MinerStatus.STARTING
-            print(f"Domain: Miner {self.id} requested to turn ON") # Placeholder
-        # Else: Already on or transitioning
+        if self.active:
+            if self.status in [MinerStatus.OFF, MinerStatus.ERROR, MinerStatus.UNKNOWN]:
+                self.status = MinerStatus.STARTING
+                print(f"Domain: Miner {self.id} requested to turn ON") # Placeholder
+        else:
+            raise MinerNotActiveError(f"Miner {self.id} is not active and cannot be turned ON.")
 
     def turn_off(self):
         # Domain logic: update status if applicable
-        if self.status in [MinerStatus.ON, MinerStatus.ERROR]:
-            self.status = MinerStatus.STOPPING
-            print(f"Domain: Miner {self.id} requested to turn OFF") # Placeholder
-        # Else: Already off or transitioning
+        if self.active:
+            if self.status in [MinerStatus.ON, MinerStatus.ERROR]:
+                self.status = MinerStatus.STOPPING
+                print(f"Domain: Miner {self.id} requested to turn OFF") # Placeholder
+            # Else: Already off or transitioning
+        else:
+            raise MinerNotActiveError(f"Miner {self.id} is not active and cannot be turned OFF.")
 
-    def update_status(self, new_status: MinerStatus, power: Optional[Watts] = None):
-        self.status = new_status
-        if power is not None:
-            self.power_consumption = power
-        print(f"Domain: Miner {self.id} status updated to {new_status}, power: {power}") # Placeholder
+    def update_status(self, new_status: MinerStatus, hash_rate: Optional[HashRate] = None, power: Optional[Watts] = None):
+        if self.active:
+            self.status = new_status
+            if hash_rate is not None:
+                self.hash_rate = hash_rate
+            if power is not None:
+                self.power_consumption = power
+            
+            # TODO: Add logic to handle max hash rate and power consumption
+            
+            print(f"Domain: Miner {self.id} status updated to {new_status}, hashrate: {hash_rate}, power: {power}") # Placeholder
+        else:
+            raise MinerNotActiveError(f"Miner {self.id} is not active and cannot update status.")
+    
+    def activate(self):
+        self.active = True
+        print(f"Domain: Miner {self.id} activated")
+    
+    def deactivate(self):
+        self.active = False
+        print(f"Domain: Miner {self.id} deactivated")

--- a/edge_mining/domain/miner/entities.py
+++ b/edge_mining/domain/miner/entities.py
@@ -25,8 +25,8 @@ class Miner:
     def turn_off(self):
         # Domain logic: update status if applicable
         if self.status in [MinerStatus.ON, MinerStatus.ERROR]:
-             self.status = MinerStatus.STOPPING
-             print(f"Domain: Miner {self.id} requested to turn OFF") # Placeholder
+            self.status = MinerStatus.STOPPING
+            print(f"Domain: Miner {self.id} requested to turn OFF") # Placeholder
         # Else: Already off or transitioning
 
     def update_status(self, new_status: MinerStatus, power: Optional[Watts] = None):

--- a/edge_mining/domain/miner/ports.py
+++ b/edge_mining/domain/miner/ports.py
@@ -6,6 +6,7 @@ from typing import Optional, List
 from edge_mining.domain.common import Watts
 from edge_mining.domain.miner.entities import Miner
 from edge_mining.domain.miner.common import MinerId, MinerStatus
+from edge_mining.domain.miner.value_objects import HashRate
 
 class MinerControlPort(ABC):
     @abstractmethod
@@ -26,6 +27,11 @@ class MinerControlPort(ABC):
     @abstractmethod
     def get_miner_power(self, miner_id: MinerId) -> Optional[Watts]:
         """Gets the current power consumption, if available."""
+        raise NotImplementedError
+    
+    @abstractmethod
+    def get_miner_hashrate(self, miner_id: MinerId) -> Optional[HashRate]:
+        """Gets the current hash rate, if available."""
         raise NotImplementedError
 
 class MinerRepository(ABC):

--- a/edge_mining/domain/miner/ports.py
+++ b/edge_mining/domain/miner/ports.py
@@ -30,6 +30,11 @@ class MinerControlPort(ABC):
 
 class MinerRepository(ABC):
     @abstractmethod
+    def generate_id(self) -> MinerId:
+        """Generates a new unique ID for a miner."""
+        raise NotImplementedError
+    
+    @abstractmethod
     def add(self, miner: Miner) -> None:
         """Adds a new miner to the repository."""
         raise NotImplementedError

--- a/edge_mining/domain/policy/aggregate_roots.py
+++ b/edge_mining/domain/policy/aggregate_roots.py
@@ -8,6 +8,7 @@ from edge_mining.domain.common import EntityId, Watts
 from edge_mining.domain.policy.common import MiningDecision
 from edge_mining.domain.policy.entities import AutomationRule
 from edge_mining.domain.miner.common import MinerStatus, MinerId
+from edge_mining.domain.miner.value_objects import HashRate
 from edge_mining.domain.forecast.value_objects import ForecastData
 from edge_mining.domain.energy.value_objects import EnergyStateSnapshot
 
@@ -28,6 +29,7 @@ class OptimizationPolicy:
         forecast: Optional[ForecastData],
         home_load_forecast: Optional[Watts], # Added home load forecast
         current_miner_status: MinerStatus,
+        hash_rate: Optional[HashRate],
         current_miner_power: Optional[Watts],
     ) -> MiningDecision:
         """

--- a/edge_mining/domain/policy/entities.py
+++ b/edge_mining/domain/policy/entities.py
@@ -28,14 +28,14 @@ class AutomationRule:
         battery_soc_lt = self.conditions.get("battery_soc_lt") # For stopping
 
         if battery_soc_gt is not None and energy_state.battery:
-             if energy_state.battery.state_of_charge <= Percentage(battery_soc_gt):
-                 return False # Condition not met
+            if energy_state.battery.state_of_charge <= Percentage(battery_soc_gt):
+                return False # Condition not met
 
         if solar_forecast_gt is not None and forecast:
-             # Assuming forecast.predicted_watts is a list or similar
-             # This needs refinement based on ForecastData structure
-             if not any(p > Watts(solar_forecast_gt) for p in forecast.predicted_watts.values()): # Simplistic check
-                 return False # Condition not met
+            # Assuming forecast.predicted_power is a list or similar
+            # This needs refinement based on ForecastData structure
+            if not any(p > Watts(solar_forecast_gt) for p in forecast.predicted_power.values()): # Simplistic check
+                return False # Condition not met
 
         if battery_soc_lt is not None and energy_state.battery:
             if energy_state.battery.state_of_charge >= Percentage(battery_soc_lt):

--- a/edge_mining/shared/external_service/port.py
+++ b/edge_mining/shared/external_service/port.py
@@ -1,0 +1,17 @@
+"""The External Service port."""
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional
+
+class ExternalServicePort(ABC):
+    """Interface for external service."""
+
+    @abstractmethod
+    def connect(self) -> None:
+        """Connect to the external service."""
+        pass
+    
+    @abstractmethod
+    def disconnect(self) -> None:
+        """Disconnect from the external service."""
+        pass

--- a/edge_mining/shared/settings/common.py
+++ b/edge_mining/shared/settings/common.py
@@ -1,0 +1,31 @@
+"""Collection of Common Objects for the Settings shared domain of the Edge Mining application."""
+
+from enum import Enum
+
+class PersistenceAdapter(Enum):
+    IN_MEMORY = "in_memory"
+    SQLITE = "sqlite"
+
+class EnergyMonitorAdapter(Enum):
+    DUMMY = "dummy"
+    HOME_ASSISTANT = "home_assistant"
+
+class MinerControllerAdapter(Enum):
+    DUMMY = "dummy"
+
+class ForecastProviderAdapter(Enum):
+    DUMMY = "dummy"
+    HOME_ASSISTANT = "home_assistant"
+
+class HomeForecastProviderAdapter(Enum):
+    DUMMY = "dummy"
+
+class NotificationAdapter(Enum):
+    DUMMY = "dummy"
+    TELEGRAM = "telegram"
+
+class PerformaceTrackerAdapter(Enum):
+    DUMMY = "dummy"
+
+class ExternalServiceAdapter(Enum):
+    HOME_ASSISTANT = "home_assistant"

--- a/edge_mining/shared/settings/settings.py
+++ b/edge_mining/shared/settings/settings.py
@@ -16,9 +16,9 @@ class AppSettings(BaseSettings):
     timezome: str = "Europe/Rome" # Default timezone
 
     # Adapters Configuration (select which ones to use)
-    energy_monitor_adapter: str = "dummy" # Options: "dummy", "home_assistant"
+    energy_monitor_adapter: str = "home_assistant" # Options: "dummy", "home_assistant"
     miner_controller_adapter: str = "dummy" # Options: "dummy", "vnish"
-    forecast_provider_adapter: str = "dummy" # Options: "dummy", "home_assistant"
+    forecast_provider_adapter: str = "home_assistant" # Options: "dummy", "home_assistant"
     home_forecast_adapter: str = "dummy" # Options: "dummy", "ml_model"
     persistence_adapter: str = "sqlite" # Options: "in_memory", "sqlite"
     notification_adapter: str = "dummy" # Options: "dummy", "telegram"
@@ -48,6 +48,8 @@ class AppSettings(BaseSettings):
     # Home Assistant Adapter Settings (if energy_monitor_adapter=home_assistant)
     home_assistant_url: Optional[str] = None # e.g., http://homeassistant.local:8123
     home_assistant_token: Optional[str] = None # Long-Lived Access Token
+    
+    # Energy Monitor Adapter (if energy_monitor_adapter=home_assistant)
     # --- Entity IDs ---
     ha_entity_solar_production: Optional[str] = None # e.g., sensor.solar_power (W or kW)
     ha_entity_house_consumption: Optional[str] = None # e.g., sensor.house_load_power (W or kW) - MUST exclude miner load!
@@ -61,6 +63,26 @@ class AppSettings(BaseSettings):
     ha_unit_battery_power: str = "W" # "W" or "kW"
     # --- Optional: Battery Capacity (if not available via an entity) ---
     ha_battery_nominal_capacity_wh: Optional[float] = None # e.g., 10000.0
+    
+    # Forecast Provider Adapter (if forecast_provider_adapter=home_assistant)
+    # --- Entity IDs ---
+    ha_entity_solar_forecast_power_actual_h: Optional[str] = None # e.g., sensor.solar_forecast_power_actual_h (W or kW)
+    ha_entity_solar_forecast_power_next_1h: Optional[str] = None # e.g., sensor.solar_forecast_power_next_1h (W or kW)
+    ha_entity_solar_forecast_power_next_12h: Optional[str] = None # e.g., sensor.solar_forecast_power_next_12h (W or kW)
+    ha_entity_solar_forecast_power_next_24h: Optional[str] = None # e.g., sensor.solar_forecast_power_next_24h (W or kW)
+    ha_entity_solar_forecast_energy_actual_h: Optional[str] = None # e.g., sensor.solar_forecast_energy_actual_h (Wh or kWh)
+    ha_entity_solar_forecast_energy_next_1h: Optional[str] = None # e.g., sensor.solar_forecast_energy_next_1h (Wh or kWh)
+    ha_entity_solar_forecast_energy_next_24h: Optional[str] = None # e.g., sensor.solar_forecast_energy_next_24h (Wh or kWh)
+    ha_entity_solar_forecast_energy_remaining_today: Optional[str] = None # e.g., sensor.solar_forecast_energy_remaining_today (Wh or kWh)
+    # --- Optional: Units (if entities report in kW instead of W) ---
+    ha_unit_solar_forecast_power_actual_h: str = "W" # "W" or "kW"
+    ha_unit_solar_forecast_power_next_1h: str = "W" # "W" or "kW"
+    ha_unit_solar_forecast_power_next_12h: str = "W" # "W" or "kW"
+    ha_unit_solar_forecast_power_next_24h: str = "W" # "W" or "kW"
+    ha_unit_solar_forecast_energy_actual_h: str = "Wh" # "Wh" or "kWh"
+    ha_unit_solar_forecast_energy_next_1h: str = "Wh" # "Wh" or "kWh"
+    ha_unit_solar_forecast_energy_next_24h: str = "Wh" # "Wh" or "kWh"
+    ha_unit_solar_forecast_energy_remaining_today: str = "Wh" # "Wh" or "kWh"
 
     # --- Grid/Battery Power Convention ---
     # Set to True if your grid sensor reports positive for EXPORTING energy


### PR DESCRIPTION
An adapter to retrieve forecast solar data from Home Assistant has been implemented. It uses the entities made available by [Forecast.Solar](https://www.home-assistant.io/integrations/forecast_solar) integration.

With this update, HomeAssistant becomes an infrastructural adapter (It is already used by at least two adapters). Some updates have also been made to the `ForecastData` value object, adding lists for predicted power and predicted energy.