### PR TITLE
Update homeassistant_api to version 5.0.0 (Issue #13)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ fastapi
 uvicorn[standard]
 
 # Optional - For specific Driven Adapters (add as needed)
-homeassistant_api==4.2.2
+homeassistant_api==5.0.0
 python-telegram-bot>=20.0


### PR DESCRIPTION
# Update homeassistant_api to version 5.0.0

## Description
This PR updates the `homeassistant_api` package from version 4.2.2 to 5.0.0 as requested in issue #13.

## Changes
- Updated `homeassistant_api` version in `requirements.txt` from 4.2.2 to 5.0.0

## Testing
- Verified working with Python 3.11

## Related Issues
Closes #13