### PR TITLE
Fix configuration instantiation for all adapter domains via REST API

### DIFF
--- a/edge_mining/adapters/domain/energy/schemas.py
+++ b/edge_mining/adapters/domain/energy/schemas.py
@@ -10,6 +10,7 @@ from edge_mining.domain.energy.common import EnergyMonitorAdapter, EnergySourceT
 from edge_mining.domain.energy.entities import EnergyMonitor, EnergySource
 from edge_mining.domain.energy.value_objects import Battery, Grid
 from edge_mining.shared.adapter_configs.energy import EnergyMonitorDummySolarConfig, EnergyMonitorHomeAssistantConfig
+from edge_mining.shared.adapter_maps.energy import ENERGY_MONITOR_CONFIG_TYPE_MAP
 from edge_mining.shared.interfaces.config import EnergyMonitorConfig
 
 
@@ -410,9 +411,12 @@ class EnergyMonitorSchema(BaseModel):
 
     def to_model(self) -> EnergyMonitor:
         """Convert EnergyMonitorSchema to EnergyMonitor domain entity."""
-        configuration: Optional[EnergyMonitorConfig] = cast(
-            EnergyMonitorConfig, EnergyMonitorConfig.from_dict(self.config) if self.config else None
-        )
+        configuration: Optional[EnergyMonitorConfig] = None
+        if self.config:
+            config_class = ENERGY_MONITOR_CONFIG_TYPE_MAP.get(self.adapter_type, None)
+            if config_class:
+                configuration = cast(EnergyMonitorConfig, config_class.from_dict(self.config))
+
         return EnergyMonitor(
             id=EntityId(uuid.UUID(self.id)),
             name=self.name,
@@ -474,9 +478,12 @@ class EnergyMonitorCreateSchema(BaseModel):
 
     def to_model(self) -> EnergyMonitor:
         """Convert EnergyMonitorCreateSchema to EnergyMonitor domain entity."""
-        configuration: Optional[EnergyMonitorConfig] = cast(
-            EnergyMonitorConfig, EnergyMonitorConfig.from_dict(self.config) if self.config else None
-        )
+        configuration: Optional[EnergyMonitorConfig] = None
+        if self.config:
+            config_class = ENERGY_MONITOR_CONFIG_TYPE_MAP.get(self.adapter_type, None)
+            if config_class:
+                configuration = cast(EnergyMonitorConfig, config_class.from_dict(self.config))
+
         return EnergyMonitor(
             id=EntityId(uuid.uuid4()),
             name=self.name,

--- a/edge_mining/adapters/domain/energy/schemas.py
+++ b/edge_mining/adapters/domain/energy/schemas.py
@@ -367,6 +367,15 @@ class EnergyMonitorSchema(BaseModel):
             v = ""
         return v
 
+    @field_validator("adapter_type")
+    @classmethod
+    def validate_adapter_type(cls, v: str) -> EnergyMonitorAdapter:
+        """Validate that adapter_type is a recognized EnergyMonitorAdapter."""
+        adapter_values = [adapter.value for adapter in EnergyMonitorAdapter]
+        if v not in adapter_values:
+            raise ValueError(f"adapter_type must be one of {adapter_values}")
+        return EnergyMonitorAdapter(v)
+
     @field_validator("external_service_id")
     @classmethod
     def validate_external_service_id(cls, v: Optional[str]) -> Optional[str]:
@@ -442,6 +451,15 @@ class EnergyMonitorCreateSchema(BaseModel):
         if not v:
             v = ""
         return v
+
+    @field_validator("adapter_type")
+    @classmethod
+    def validate_adapter_type(cls, v: str) -> EnergyMonitorAdapter:
+        """Validate that adapter_type is a recognized EnergyMonitorAdapter."""
+        adapter_values = [adapter.value for adapter in EnergyMonitorAdapter]
+        if v not in adapter_values:
+            raise ValueError(f"adapter_type must be one of {adapter_values}")
+        return EnergyMonitorAdapter(v)
 
     @field_validator("external_service_id")
     @classmethod

--- a/edge_mining/adapters/domain/miner/schemas.py
+++ b/edge_mining/adapters/domain/miner/schemas.py
@@ -276,6 +276,15 @@ class MinerControllerSchema(BaseModel):
             v = ""
         return v
 
+    @field_validator("adapter_type")
+    @classmethod
+    def validate_adapter_type(cls, v: str) -> MinerControllerAdapter:
+        """Validate that adapter_type is a recognized MinerControllerAdapter."""
+        adapter_values = [adapter.value for adapter in MinerControllerAdapter]
+        if v not in adapter_values:
+            raise ValueError(f"adapter_type must be one of {adapter_values}")
+        return MinerControllerAdapter(v)
+
     @field_validator("external_service_id")
     @classmethod
     def validate_external_service_id(cls, v: Optional[str]) -> Optional[str]:
@@ -352,6 +361,15 @@ class MinerControllerCreateSchema(BaseModel):
         if not v:
             v = ""
         return v
+
+    @field_validator("adapter_type")
+    @classmethod
+    def validate_adapter_type(cls, v: str) -> MinerControllerAdapter:
+        """Validate that adapter_type is a recognized MinerControllerAdapter."""
+        adapter_values = [adapter.value for adapter in MinerControllerAdapter]
+        if v not in adapter_values:
+            raise ValueError(f"adapter_type must be one of {adapter_values}")
+        return MinerControllerAdapter(v)
 
     @field_validator("external_service_id")
     @classmethod

--- a/edge_mining/adapters/domain/miner/schemas.py
+++ b/edge_mining/adapters/domain/miner/schemas.py
@@ -13,6 +13,7 @@ from edge_mining.shared.adapter_configs.miner import (
     MinerControllerDummyConfig,
     MinerControllerGenericSocketHomeAssistantAPIConfig,
 )
+from edge_mining.shared.adapter_maps.miner import MINER_CONTROLLER_CONFIG_TYPE_MAP
 from edge_mining.shared.interfaces.config import MinerControllerConfig
 
 
@@ -319,9 +320,11 @@ class MinerControllerSchema(BaseModel):
 
     def to_model(self) -> MinerController:
         """Convert MinerControllerSchema to MinerController domain model instance."""
-        configuration: Optional[MinerControllerConfig] = cast(
-            MinerControllerConfig, MinerControllerConfig.from_dict(self.config) if self.config else {}
-        )
+        configuration: Optional[MinerControllerConfig] = None
+        if self.config:
+            config_class = MINER_CONTROLLER_CONFIG_TYPE_MAP.get(self.adapter_type, None)
+            if config_class:
+                configuration = cast(MinerControllerConfig, config_class.from_dict(self.config))
 
         return MinerController(
             id=EntityId(uuid.UUID(self.id)),
@@ -384,9 +387,11 @@ class MinerControllerCreateSchema(BaseModel):
 
     def to_model(self) -> MinerController:
         """Convert MinerControllerCreateSchema to a MinerController domain model instance."""
-        configuration: Optional[MinerControllerConfig] = cast(
-            MinerControllerConfig, MinerControllerConfig.from_dict(self.config) if self.config else None
-        )
+        configuration: Optional[MinerControllerConfig] = None
+        if self.config:
+            config_class = MINER_CONTROLLER_CONFIG_TYPE_MAP.get(self.adapter_type, None)
+            if config_class:
+                configuration = cast(MinerControllerConfig, config_class.from_dict(self.config))
 
         return MinerController(
             id=EntityId(uuid.uuid4()),

--- a/edge_mining/adapters/infrastructure/external_services/schemas.py
+++ b/edge_mining/adapters/infrastructure/external_services/schemas.py
@@ -56,6 +56,15 @@ class ExternalServiceSchema(BaseModel):
             v = ""
         return v
 
+    @field_validator("adapter_type")
+    @classmethod
+    def validate_adapter_type(cls, v: str) -> ExternalServiceAdapter:
+        """Validate that adapter_type is a recognized ExternalServiceAdapter."""
+        adapter_values = [adapter.value for adapter in ExternalServiceAdapter]
+        if v not in adapter_values:
+            raise ValueError(f"adapter_type must be one of {adapter_values}")
+        return ExternalServiceAdapter(v)
+
     @field_serializer("id")
     def serialize_id(self, id_value: EntityId) -> str:
         """Serialize EntityId to string."""
@@ -112,6 +121,15 @@ class ExternalServiceCreateSchema(BaseModel):
         if not v:
             v = ""
         return v
+
+    @field_validator("adapter_type")
+    @classmethod
+    def validate_adapter_type(cls, v: str) -> ExternalServiceAdapter:
+        """Validate that adapter_type is a recognized ExternalServiceAdapter."""
+        adapter_values = [adapter.value for adapter in ExternalServiceAdapter]
+        if v not in adapter_values:
+            raise ValueError(f"adapter_type must be one of {adapter_values}")
+        return ExternalServiceAdapter(v)
 
     def to_model(self) -> ExternalService:
         """Convert ExternalServiceCreateSchema to ExternalService domain entity."""

--- a/edge_mining/adapters/infrastructure/external_services/schemas.py
+++ b/edge_mining/adapters/infrastructure/external_services/schemas.py
@@ -18,6 +18,7 @@ from edge_mining.domain.common import EntityId
 # from edge_mining.domain.miner.entities import MinerController
 # from edge_mining.domain.notification.entities import Notifier
 from edge_mining.shared.adapter_configs.external_services import ExternalServiceHomeAssistantConfig
+from edge_mining.shared.adapter_maps.external_services import EXTERNAL_SERVICE_CONFIG_TYPE_MAP
 from edge_mining.shared.external_services.common import ExternalServiceAdapter
 from edge_mining.shared.external_services.entities import ExternalService
 
@@ -72,9 +73,12 @@ class ExternalServiceSchema(BaseModel):
 
     def to_model(self) -> ExternalService:
         """Convert ExternalServiceSchema to ExternalService domain entity."""
-        configuration: Optional[ExternalServiceConfig] = cast(
-            ExternalServiceConfig, ExternalServiceConfig.from_dict(self.config) if self.config else {}
-        )
+        configuration: Optional[ExternalServiceConfig] = None
+        if self.config:
+            config_class = EXTERNAL_SERVICE_CONFIG_TYPE_MAP.get(self.adapter_type, None)
+            if config_class:
+                configuration = cast(ExternalServiceConfig, config_class.from_dict(self.config))
+
         return ExternalService(
             id=EntityId(uuid.uuid4()),
             name=self.name,
@@ -133,9 +137,12 @@ class ExternalServiceCreateSchema(BaseModel):
 
     def to_model(self) -> ExternalService:
         """Convert ExternalServiceCreateSchema to ExternalService domain entity."""
-        configuration: Optional[ExternalServiceConfig] = cast(
-            ExternalServiceConfig, ExternalServiceConfig.from_dict(self.config) if self.config else {}
-        )
+        configuration: Optional[ExternalServiceConfig] = None
+        if self.config:
+            config_class = EXTERNAL_SERVICE_CONFIG_TYPE_MAP.get(self.adapter_type, None)
+            if config_class:
+                configuration = cast(ExternalServiceConfig, config_class.from_dict(self.config))
+
         return ExternalService(
             id=EntityId(uuid.uuid4()),
             name=self.name,


### PR DESCRIPTION
This PR addresses the issue #42 where configuration objects for adapters (across all domains) were not being correctly instantiated from REST API schemas. The main changes include:

## Summary
Refactored schema-to-domain conversion to use the correct configuration class based on the adapter type.
Utilized mapping dictionaries (e.g., `ENERGY_MONITOR_CONFIG_TYPE_MAP`) to dynamically select the appropriate config class.
Improved error handling for missing or invalid configuration data in API endpoints.