### PR TITLE
fix: sun midnight calculation and notifier list initialization

### DIFF
--- a/edge_mining/adapters/infrastructure/sun/factories.py
+++ b/edge_mining/adapters/infrastructure/sun/factories.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 
 from astral import LocationInfo
-from astral.sun import sun, daylight, night, twilight, zenith_and_azimuth, elevation
+from astral.sun import sun, daylight, night, twilight, midnight, zenith_and_azimuth, elevation
 
 from edge_mining.application.interfaces import SunFactoryInterface
 from edge_mining.domain.policy.value_objects import Sun
@@ -58,11 +58,14 @@ class AstralSunFactory(SunFactoryInterface):
         # Calculate elevation
         elevation_value = elevation(self._location.observer, dateandtime=for_date)
 
+        # Obtain midnight time
+        midnight_time = midnight(self._location.observer, date=for_date)
+
         return Sun(
             dawn=s["dawn"],
             sunrise=s["sunrise"],
             noon=s["noon"],
-            midnight=s["midnight"],
+            midnight=midnight_time,
             sunset=s["sunset"],
             dusk=s["dusk"],
             daylight=daylight_duration,

--- a/edge_mining/application/services/adapter_service.py
+++ b/edge_mining/application/services/adapter_service.py
@@ -630,7 +630,7 @@ class AdapterService(AdapterServiceInterface):
 
     def get_notifiers(self, notifier_ids: List[EntityId]) -> List[NotificationPort]:
         """Get a list of specific notifier adapter instances by IDs."""
-        notifier_instances = List[NotificationPort]()
+        notifier_instances: List[NotificationPort] = []
         for notifier_id in notifier_ids:
             notifier = self.notifier_repo.get_by_id(notifier_id)
             if not notifier:


### PR DESCRIPTION
This PR addresses issues #47 and #48.

It replaces midnight assignment in `AstralSunFactory` with proper calculation using `astral.sun.midnight`.
Also corrects `notifier_instances` initialization in `AdapterService` to use an empty list together with a type hint.