### PR TITLE
feat: enhance miner controller configuration to support current config defaults

### DIFF
--- a/edge_mining/adapters/domain/miner/cli/commands.py
+++ b/edge_mining/adapters/domain/miner/cli/commands.py
@@ -487,13 +487,49 @@ def select_miner_controller_type() -> Optional[MinerControllerAdapter]:
 
 def handle_miner_controller_dummy_config(
     miner: Optional[Miner],
+    current_config: Optional[MinerControllerConfig] = None,
 ) -> MinerControllerConfig:
     """Handle configuration for the Dummy Miner Controller."""
     click.echo(click.style("\n--- Dummy Miner Controller Configuration ---", fg="yellow"))
 
-    default_power = miner.power_consumption_max if miner else 3200.0
-    default_hash_rate = miner.hash_rate_max.value if miner and miner.hash_rate_max else 90.0
-    default_hash_rate_unit = miner.hash_rate_max.unit if miner and miner.hash_rate_max else "TH/s"
+    # Try to get defaults from current_config, fallback to miner, then to hardcoded values
+    default_power = (
+        (current_config.get("power_max") if current_config and current_config.get("power_max") is not None else None)
+        or (
+            miner.power_consumption_max if miner and getattr(miner, "power_consumption_max", None) is not None else None
+        )
+        or 3200.0
+    )
+    default_hash_rate = (
+        (
+            current_config.get("hashrate_max", {}).get("value")
+            if current_config and current_config.get("hashrate_max", {})
+            else None
+        )
+        or (
+            miner.hash_rate_max.value
+            if miner
+            and getattr(miner, "hash_rate_max", None)
+            and getattr(miner.hash_rate_max, "value", None) is not None
+            else None
+        )
+        or 90.0
+    )
+    default_hash_rate_unit = (
+        (
+            current_config.get("hashrate_max", {}).get("unit")
+            if current_config and current_config.get("hashrate_max", {})
+            else None
+        )
+        or (
+            miner.hash_rate_max.unit
+            if miner
+            and getattr(miner, "hash_rate_max", None)
+            and getattr(miner.hash_rate_max, "unit", None) is not None
+            else None
+        )
+        or "TH/s"
+    )
 
     power_max: float = click.prompt(
         "Max power consumption (Watt, eg. 3200.0)",
@@ -513,24 +549,42 @@ def handle_miner_controller_dummy_config(
     )
 
 
-def handle_miner_controller_generic_socket_home_assistant_api_config(miner: Optional[Miner]) -> MinerControllerConfig:
+def handle_miner_controller_generic_socket_home_assistant_api_config(
+    miner: Optional[Miner],
+    current_config: Optional[MinerControllerConfig] = None,
+) -> MinerControllerConfig:
     """Handle configuration for the Generic Socket Home Assistant API Miner Controller."""
     click.echo(click.style("\n--- Generic Socket Home Assistant API Miner Controller Configuration ---", fg="yellow"))
+
+    # Try to get defaults from current_config, fallback to hardcoded values
+    default_entity_switch = (
+        current_config.get("entity_switch")
+        if current_config and current_config.get("entity_switch") is not None
+        else "switch.miner_socket"
+    )
+    default_entity_power = (
+        current_config.get("entity_power")
+        if current_config and current_config.get("entity_power") is not None
+        else "sensor.miner_power"
+    )
+    default_unit_power = (
+        current_config.get("unit_power") if current_config and current_config.get("unit_power") is not None else "W"
+    )
 
     entity_switch: str = click.prompt(
         "Entity ID for the switch (eg. switch.miner_socket)",
         type=str,
-        default="switch.miner_socket",
+        default=default_entity_switch,
     )
     entity_power: str = click.prompt(
         "Entity ID for the power sensor (eg. sensor.miner_power)",
         type=str,
-        default="sensor.miner_power",
+        default=default_entity_power,
     )
     unit_power: str = click.prompt(
         "Unit of power measurement (eg. W, kW)",
         type=str,
-        default="W",
+        default=default_unit_power,
     )
 
     return MinerControllerGenericSocketHomeAssistantAPIConfig(
@@ -541,14 +595,17 @@ def handle_miner_controller_generic_socket_home_assistant_api_config(miner: Opti
 
 
 def handle_miner_controller_configuration(
-    adapter_type: MinerControllerAdapter, miner: Optional[Miner]
+    adapter_type: MinerControllerAdapter,
+    miner: Optional[Miner],
+    current_config: Optional[MinerControllerConfig] = None,
 ) -> Optional[MinerControllerConfig]:
     """Handle configuration for the selected Miner Controller type."""
     config: Optional[MinerControllerConfig] = None
+
     if adapter_type.value == MinerControllerAdapter.DUMMY.value:
-        config = handle_miner_controller_dummy_config(miner)
+        config = handle_miner_controller_dummy_config(miner, current_config=current_config)
     elif adapter_type.value == MinerControllerAdapter.GENERIC_SOCKET_HOME_ASSISTANT_API.value:
-        config = handle_miner_controller_generic_socket_home_assistant_api_config(miner)
+        config = handle_miner_controller_generic_socket_home_assistant_api_config(miner, current_config=current_config)
     else:
         click.echo(click.style("Unsupported controller type selected. Aborting.", fg="red"))
     return config
@@ -744,9 +801,16 @@ def update_single_miner_controller(
 ) -> Optional[MinerController]:
     """Menu to update a miner controller"""
     name: str = click.prompt("New name of the controller", type=str, default=controller.name)
+
+    # Get current config to pass as default
+    current_config: Optional[MinerControllerConfig] = getattr(controller, "config", None)
+    # Get current external service id
+    external_service_id: Optional[EntityId] = getattr(controller, "external_service_id", None)
+
     config: Optional[MinerControllerConfig] = handle_miner_controller_configuration(
         adapter_type=controller.adapter_type,
         miner=None,  # No miner needed for controller update
+        current_config=current_config.to_dict(),  # Current config values as default
     )
 
     if config is None:
@@ -755,7 +819,7 @@ def update_single_miner_controller(
 
     try:
         updated_controller = configuration_service.update_miner_controller(
-            controller_id=controller.id, name=name, config=config
+            controller_id=controller.id, name=name, config=config, external_service_id=external_service_id
         )
         logger.info(f"Miner Controller '{updated_controller.name}' (ID: {updated_controller.id}) successfully updated.")
     except Exception as e:

--- a/edge_mining/adapters/domain/miner/cli/commands.py
+++ b/edge_mining/adapters/domain/miner/cli/commands.py
@@ -492,23 +492,18 @@ def handle_miner_controller_dummy_config(
     """Handle configuration for the Dummy Miner Controller."""
     click.echo(click.style("\n--- Dummy Miner Controller Configuration ---", fg="yellow"))
 
-    # Try to get defaults from current_config, fallback to miner, then to hardcoded values
+    # Defaults from miner if available or hardcoded values
+    default_power = miner.power_consumption_max if miner else 3200.0
+    default_hash_rate = miner.hash_rate_max.value if miner and miner.hash_rate_max else 90.0
+    default_hash_rate_unit = miner.hash_rate_max.unit if miner and miner.hash_rate_max else "TH/s"
+
+    # Try to get defaults from current_config
     if current_config and current_config.is_valid(MinerControllerAdapter.DUMMY):
         config: MinerControllerDummyConfig = cast(MinerControllerDummyConfig, current_config)
-        # Check if hash_rate_max is a dict
-        if isinstance(config.hashrate_max, dict):
-            config = MinerControllerDummyConfig(
-                initial_status=config.initial_status,
-                power_max=config.power_max,
-                hashrate_max=HashRate(**config.hashrate_max),
-            )
+
         default_power = config.power_max
         default_hash_rate = config.hashrate_max.value
         default_hash_rate_unit = config.hashrate_max.unit
-    else:
-        default_power = miner.power_consumption_max if miner else 3200.0
-        default_hash_rate = miner.hash_rate_max.value if miner and miner.hash_rate_max else 90.0
-        default_hash_rate_unit = miner.hash_rate_max.unit if miner and miner.hash_rate_max else "TH/s"
 
     power_max: float = click.prompt(
         "Max power consumption (Watt, eg. 3200.0)",
@@ -535,7 +530,12 @@ def handle_miner_controller_generic_socket_home_assistant_api_config(
     """Handle configuration for the Generic Socket Home Assistant API Miner Controller."""
     click.echo(click.style("\n--- Generic Socket Home Assistant API Miner Controller Configuration ---", fg="yellow"))
 
-    # Try to get defaults from current_config, fallback to hardcoded values
+    # Default values from hardcoded values
+    default_entity_switch = "switch.miner_socket"
+    default_entity_power = "sensor.miner_power"
+    default_unit_power = "W"
+
+    # Try to get defaults from current_config
     if current_config and current_config.is_valid(MinerControllerAdapter.GENERIC_SOCKET_HOME_ASSISTANT_API):
         config: MinerControllerGenericSocketHomeAssistantAPIConfig = cast(
             MinerControllerGenericSocketHomeAssistantAPIConfig, current_config
@@ -543,10 +543,6 @@ def handle_miner_controller_generic_socket_home_assistant_api_config(
         default_entity_switch = config.entity_switch
         default_entity_power = config.entity_power
         default_unit_power = config.unit_power
-    else:
-        default_entity_switch = "switch.miner_socket"
-        default_entity_power = "sensor.miner_power"
-        default_unit_power = "W"
 
     entity_switch: str = click.prompt(
         "Entity ID for the switch (eg. switch.miner_socket)",

--- a/edge_mining/shared/adapter_configs/miner.py
+++ b/edge_mining/shared/adapter_configs/miner.py
@@ -35,7 +35,18 @@ class MinerControllerDummyConfig(MinerControllerConfig):
     @classmethod
     def from_dict(cls, data: dict):
         """Create a configuration object from a dictionary"""
-        return cls(**data)
+        hashrate_max = HashRate(90, "TH/s")
+        if "hashrate_max" in data:
+            hashrate_dict: dict = data.get("hashrate_max")
+            hashrate_max = HashRate(
+                value=hashrate_dict.get("value", 90),
+                unit=hashrate_dict.get("unit", "TH/s"),
+            )
+        return MinerControllerDummyConfig(
+            initial_status=data.get("initial_status", "UNKNOWN"),
+            power_max=data.get("power_max", 3200.0),
+            hashrate_max=hashrate_max,
+        )
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
This pull request introduces an enhancement to the miner controller configuration flow.

* **Feature**: When updating a miner controller, the current configuration values are now used as defaults. It also keeps track of the external service id reference.

Closes #20
