### PR TITLE
fix: update from_dict method in EnergyMonitorDummySolarConfig to handle max_consumption_power correctly

### DIFF
--- a/edge_mining/shared/adapter_configs/energy.py
+++ b/edge_mining/shared/adapter_configs/energy.py
@@ -27,7 +27,8 @@ class EnergyMonitorDummySolarConfig(EnergyMonitorConfig):
     @classmethod
     def from_dict(cls, data: dict):
         """Create a configuration object from a dictionary"""
-        return cls(**data)
+        max_consumption_power = Watts(data.get("max_consumption_power", 3200.0))
+        return EnergyMonitorDummySolarConfig(max_consumption_power=max_consumption_power)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
By creating an instance of `EnergyMonitorDummySolarConfig` using the method `from_dict()`, the returned instance did not have the correct type of properties. In this case `Watts`.

With this correction the correct type is returned.