### PR TITLE
Implemented Energy Optimization Unit management from CLI and Rest API

### DIFF
--- a/edge_mining/__main__.py
+++ b/edge_mining/__main__.py
@@ -92,7 +92,7 @@ def main():
     finally:
         # Sure to flush logs before exiting
         logger.shutdown()
-        sys.exit(1)
+        sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/edge_mining/adapters/domain/energy/cli/commands.py
+++ b/edge_mining/adapters/domain/energy/cli/commands.py
@@ -431,7 +431,6 @@ def print_energy_source_details(
     configuration_service: ConfigurationServiceInterface,
     show_energy_monitor_list: bool = False,
     show_forecast_provider_list: bool = False,
-    show_energy_source_list: bool = False,
 ) -> None:
     """Print the details of an energy source."""
     click.echo("")
@@ -461,7 +460,7 @@ def print_energy_source_details(
                     energy_monitor,
                     configuration_service,
                     show_external_service=True,
-                    show_energy_source_list=show_energy_source_list,
+                    show_energy_source_list=False,
                 )
             else:
                 click.echo(
@@ -481,7 +480,7 @@ def print_energy_source_details(
                 print_forecast_provider_details(
                     forecast_provider,
                     configuration_service,
-                    show_energy_source_list=show_energy_source_list,
+                    show_energy_source_list=False,
                 )
             else:
                 click.echo(
@@ -738,7 +737,6 @@ def manage_single_energy_source_menu(
             configuration_service=configuration_service,
             show_energy_monitor_list=True,
             show_forecast_provider_list=True,
-            show_energy_source_list=False,
         )
 
         click.echo("1. Update Energy Source")

--- a/edge_mining/adapters/domain/energy/cli/commands.py
+++ b/edge_mining/adapters/domain/energy/cli/commands.py
@@ -429,8 +429,8 @@ def print_energy_monitor_details(
 def print_energy_source_details(
     energy_source: EnergySource,
     configuration_service: ConfigurationServiceInterface,
-    show_energy_monitor_list: bool = False,
-    show_forecast_provider_list: bool = False,
+    show_energy_monitor_details: bool = False,
+    show_forecast_provider_details: bool = False,
 ) -> None:
     """Print the details of an energy source."""
     click.echo("")
@@ -447,7 +447,7 @@ def print_energy_source_details(
         + ((str(energy_source.external_source) + " W") if energy_source.external_source else "None")
     )
 
-    if show_energy_monitor_list:
+    if show_energy_monitor_details:
         if energy_source.energy_monitor_id:
             try:
                 energy_monitor = configuration_service.get_energy_monitor(energy_source.energy_monitor_id)
@@ -468,7 +468,7 @@ def print_energy_source_details(
                 )
             click.echo("")
 
-    if show_forecast_provider_list:
+    if show_forecast_provider_details:
         if energy_source.forecast_provider_id:
             try:
                 forecast_provider = configuration_service.get_forecast_provider(energy_source.forecast_provider_id)
@@ -735,8 +735,8 @@ def manage_single_energy_source_menu(
         print_energy_source_details(
             energy_source=energy_source,
             configuration_service=configuration_service,
-            show_energy_monitor_list=True,
-            show_forecast_provider_list=True,
+            show_energy_monitor_details=True,
+            show_forecast_provider_details=True,
         )
 
         click.echo("1. Update Energy Source")

--- a/edge_mining/adapters/domain/miner/cli/commands.py
+++ b/edge_mining/adapters/domain/miner/cli/commands.py
@@ -1,6 +1,6 @@
 """CLI commands for the Miner domain."""
 
-from typing import List, Optional
+from typing import List, Optional, Union
 
 import click
 
@@ -145,14 +145,31 @@ def select_miner(
     configuration_service: ConfigurationServiceInterface,
     logger: LoggerPort,
     default_id: Optional[EntityId] = None,
-) -> Optional[Miner]:
-    """Select a miner from the list."""
-    click.echo(click.style("\n--- Select Miner ---", fg="yellow"))
+    allow_multiple: bool = False,
+    only_ids: Optional[List[EntityId]] = None,
+    exclude_ids: Optional[List[EntityId]] = None,
+) -> Union[Optional[Miner], List[Miner]]:
+    """Select one ore more miners from the list."""
 
     miners = configuration_service.list_miners()
     if not miners:
         click.echo(click.style("No miner configured.", fg="yellow"))
         return None
+    else:
+        if only_ids:
+            miners = [m for m in miners if m.id in only_ids]
+        if exclude_ids:
+            miners = [m for m in miners if m.id not in exclude_ids]
+        if not miners:
+            click.echo(click.style("No miner available after applying filters.", fg="yellow"))
+            return None
+        elif len(miners) == 1:
+            allow_multiple = False
+
+    if allow_multiple:
+        click.echo(click.style("\n--- Select Miners ---", fg="yellow"))
+    else:
+        click.echo(click.style("\n--- Select Miner ---", fg="yellow"))
 
     default_idx = ""
     for idx, m in enumerate(miners):
@@ -166,8 +183,8 @@ def select_miner(
             + "Max Power: "
             + click.style(f"{m.power_consumption_max}W, ", fg="cyan")
             + "Max HashRate: "
-            + click.style(f"{hashrate_str}", fg="magenta")
-            + "Active:"
+            + click.style(f"{hashrate_str}, ", fg="magenta")
+            + "Active: "
             + click.style(f"{m.active}", fg="green" if m.active else "red")
         )
 
@@ -177,17 +194,51 @@ def select_miner(
 
     click.echo("\nb. Back to menu\n")
 
-    miner_idx: str = click.prompt("Choose a Miner index", type=str, default=default_idx)
-    miner_idx = miner_idx.strip().lower()
-    if miner_idx == "b":
-        return None
+    if allow_multiple:
+        miner_indices: str = click.prompt(
+            "Choose Miner indices (comma-separated, e.g., 0,2,3)", type=str, default=default_idx
+        )
+        miner_indices = miner_indices.strip().lower()
+        if miner_indices == "b":
+            return None
 
-    if not miner_idx.isdigit() or int(miner_idx) < 0 or int(miner_idx) >= len(miners):
-        click.echo(click.style("Invalid index. Aborting selection.", fg="red"))
-        return None
+        # Parse comma-separated indices
+        selected_miners = []
+        try:
+            indices = [idx.strip() for idx in miner_indices.split(",")]
+            for idx_str in indices:
+                if not idx_str.isdigit():
+                    click.echo(click.style(f"Invalid index '{idx_str}'. Skipping.", fg="yellow"))
+                    continue
 
-    selected_miner = miners[int(miner_idx)]
-    return selected_miner
+                idx = int(idx_str)
+                if idx < 0 or idx >= len(miners):
+                    click.echo(click.style(f"Index {idx} out of range. Skipping.", fg="yellow"))
+                    continue
+
+                selected_miners.append(miners[idx])
+
+            if not selected_miners:
+                click.echo(click.style("No valid miners selected. Aborting selection.", fg="red"))
+                return None
+
+            return selected_miners
+
+        except Exception as e:
+            click.echo(click.style(f"Error parsing indices: {e}. Aborting selection.", fg="red"))
+            return None
+    else:
+        miner_idx: str = click.prompt("Choose a Miner index", type=str, default=default_idx)
+        miner_idx = miner_idx.strip().lower()
+        if miner_idx == "b":
+            return None
+
+        if not miner_idx.isdigit() or int(miner_idx) < 0 or int(miner_idx) >= len(miners):
+            click.echo(click.style("Invalid index. Aborting selection.", fg="red"))
+            return None
+
+        selected_miner = miners[int(miner_idx)]
+        return selected_miner
 
 
 def update_single_miner(
@@ -332,6 +383,9 @@ def handle_manage_miner(configuration_service: ConfigurationServiceInterface, lo
         click.echo(click.style("No miner selected. Aborting.", fg="red"))
         return "b"
 
+    if isinstance(selected_miner, list):
+        selected_miner = selected_miner[0]  # Just pick the first one for management
+
     choice = manage_single_miner_menu(
         miner=selected_miner,
         configuration_service=configuration_service,
@@ -344,6 +398,8 @@ def handle_manage_miner(configuration_service: ConfigurationServiceInterface, lo
 def print_miner_details(
     miner: Miner,
     configuration_service: ConfigurationServiceInterface,
+    show_controller_details: bool = True,
+    show_external_service: bool = True,
 ) -> None:
     """Print details of a selected miner."""
     click.echo("")
@@ -367,14 +423,20 @@ def print_miner_details(
     click.echo("| Active: " + click.style(miner.active, fg="green" if miner.active else "red"))
     click.echo("| Controller ID: " + (str(miner.controller_id) if miner.controller_id else "None"))
 
-    if miner.controller_id:
-        controller = configuration_service.get_miner_controller(miner.controller_id)
-        if controller:
-            click.echo("\nCONTROLLER DETAILS:")
-            print_miner_controller_details(controller, configuration_service, False, True)
-        else:
-            # If the controller is not found, we can still show the ID
-            click.echo("| Controller ID: " + click.style(str(miner.controller_id), fg="red") + " (not found)")
+    if show_controller_details:
+        if miner.controller_id:
+            controller = configuration_service.get_miner_controller(miner.controller_id)
+            if controller:
+                click.echo("\nCONTROLLER DETAILS:")
+                print_miner_controller_details(
+                    controller=controller,
+                    configuration_service=configuration_service,
+                    show_miner_list=False,
+                    show_external_service=show_external_service,
+                )
+            else:
+                # If the controller is not found, we can still show the ID
+                click.echo("| Controller ID: " + click.style(str(miner.controller_id), fg="red") + " (not found)")
 
     click.echo("")
 

--- a/edge_mining/adapters/domain/notification/cli/commands.py
+++ b/edge_mining/adapters/domain/notification/cli/commands.py
@@ -1,9 +1,13 @@
 """CLI commands for the notification domain."""
 
-from typing import List, Optional
+from typing import List, Optional, Union
 
 import click
 
+from edge_mining.adapters.infrastructure.cli.utils import (
+    print_configuration,
+    process_filters,
+)
 from edge_mining.adapters.infrastructure.external_services.cli.commands import (
     handle_add_external_service,
     print_external_service_details,
@@ -23,11 +27,6 @@ from edge_mining.shared.adapter_maps.notification import (
 from edge_mining.shared.external_services.entities import ExternalService
 from edge_mining.shared.interfaces.config import NotificationConfig
 from edge_mining.shared.logging.port import LoggerPort
-
-from edge_mining.adapters.infrastructure.cli.utils import (
-    process_filters,
-    print_configuration,
-)
 
 
 def select_notifier_adapter() -> Optional[NotificationAdapter]:
@@ -197,11 +196,28 @@ def select_notifier(
     logger: LoggerPort,
     default_id: Optional[EntityId] = None,
     filter_type: Optional[List[NotificationAdapter]] = None,
-) -> Optional[Notifier]:
-    """Select a notifier from the list."""
-    click.echo(click.style("\n--- Select Notifier ---", fg="yellow"))
+    allow_multiple: bool = False,
+    only_ids: Optional[List[EntityId]] = None,
+    exclude_ids: Optional[List[EntityId]] = None,
+) -> Union[Optional[Notifier], List[Notifier]]:
+    """Select one or more notifiers from the list."""
 
     notifiers: List[Notifier] = configuration_service.list_notifiers()
+    if not notifiers:
+        allow_multiple = False
+    else:
+        if only_ids:
+            notifiers = [n for n in notifiers if n.id in only_ids]
+        if exclude_ids:
+            notifiers = [n for n in notifiers if n.id not in exclude_ids]
+        if len(notifiers) == 1:
+            allow_multiple = False
+
+    if allow_multiple:
+        click.echo(click.style("\n--- Select Notifiers ---", fg="yellow"))
+    else:
+        click.echo(click.style("\n--- Select Notifier ---", fg="yellow"))
+
     if not notifiers:
         click.echo(click.style("No notifiers configured.", fg="yellow"))
         return None
@@ -231,17 +247,48 @@ def select_notifier(
 
     click.echo("\nb. Back to menu\n")
 
-    n_idx: str = click.prompt("Choose a Notifier index", type=str, default=default_idx)
-    n_idx = n_idx.strip().lower()
-    if n_idx == "b":
-        return None
+    if allow_multiple:
+        notifier_indices: str = click.prompt("Choose Notifier indices (comma separated)", type=str, default=default_idx)
+        notifier_indices = notifier_indices.strip().lower()
+        if notifier_indices == "b":
+            return None
 
-    if not n_idx.isdigit() or int(n_idx) < 0 or int(n_idx) >= len(notifiers):
-        click.echo(click.style("Invalid index. Aborting selection.", fg="red"))
-        return None
+        # Parse comma-separated indices
+        selected_notifiers: List[Notifier] = []
+        try:
+            indices = [idx.strip() for idx in notifier_indices.split(",")]
+            for idx_str in indices:
+                if not idx_str.isdigit():
+                    click.echo(click.style(f"Invalid index '{idx_str}'. Skipping.", fg="yellow"))
+                    continue
 
-    selected_n = notifiers[int(n_idx)]
-    return selected_n
+                idx = int(idx_str)
+                if idx < 0 or idx >= len(notifiers):
+                    click.echo(click.style(f"Index {idx} out of range. Skipping.", fg="yellow"))
+                    continue
+
+                selected_notifiers.append(notifiers[idx])
+
+            if not selected_notifiers:
+                click.echo(click.style("No valid notifiers selected. Aborting selection.", fg="red"))
+                return None
+
+            return selected_notifiers
+        except Exception as e:
+            click.echo(click.style(f"Error parsing indices: {e}. Aborting selection.", fg="red"))
+            return None
+    else:
+        n_idx: str = click.prompt("Choose a Notifier index", type=str, default=default_idx)
+        n_idx = n_idx.strip().lower()
+        if n_idx == "b":
+            return None
+
+        if not n_idx.isdigit() or int(n_idx) < 0 or int(n_idx) >= len(notifiers):
+            click.echo(click.style("Invalid index. Aborting selection.", fg="red"))
+            return None
+
+        selected_n = notifiers[int(n_idx)]
+        return selected_n
 
 
 def print_notifier_config(notifier: Notifier) -> None:
@@ -613,6 +660,9 @@ def handle_manage_notifier(configuration_service: ConfigurationServiceInterface,
     if selected_notifier is None:
         click.echo(click.style("No notifier selected. Aborting.", fg="red"))
         return "b"
+
+    if isinstance(selected_notifier, list):
+        selected_notifier = selected_notifier[0]
 
     choice = manage_single_notifier_menu(
         notifier=selected_notifier,

--- a/edge_mining/adapters/domain/optimization_unit/cli/commands.py
+++ b/edge_mining/adapters/domain/optimization_unit/cli/commands.py
@@ -1,47 +1,93 @@
 """CLI commands for the Energy Optimization Unit domain."""
 
-from uuid import UUID
+from typing import List, Optional, Union
+
 import click
 
+from edge_mining.adapters.domain.energy.cli.commands import print_energy_source_details, select_energy_source
+from edge_mining.adapters.domain.miner.cli.commands import print_miner_details, select_miner
+from edge_mining.adapters.domain.notification.cli.commands import print_notifier_details, select_notifier
+from edge_mining.adapters.domain.policy.cli.commands import (
+    print_optimization_policy_details,
+    select_optimization_policy,
+)
 from edge_mining.application.interfaces import ConfigurationServiceInterface
 from edge_mining.domain.common import EntityId
+from edge_mining.domain.energy.entities import EnergySource
+from edge_mining.domain.miner.entities import Miner
+from edge_mining.domain.notification.entities import Notifier
+from edge_mining.domain.optimization_unit.aggregate_roots import EnergyOptimizationUnit
+from edge_mining.domain.policy.aggregate_roots import OptimizationPolicy
 from edge_mining.shared.logging.port import LoggerPort
 
 
-def handle_create_optimization_unit(configuration_service: ConfigurationServiceInterface, logger: LoggerPort):
-    """Menu to create a new optimization unit."""
+def handle_add_optimization_unit(configuration_service: ConfigurationServiceInterface, logger: LoggerPort):
+    """Menu to add a new optimization unit."""
 
     click.echo(click.style("\n--- Creates a new Energy Optimization Unit ---", fg="yellow"))
 
     name: str = click.prompt("Name of the energy optimization unit", type=str)
     description: str = click.prompt("Description (optional)", type=str, default="")
-    energy_source_id: str = click.prompt("Energy source ID (optional)", type=str, default="")
-    target_miner_ids_str: str = click.prompt("Miner target IDs (comma separated, optional)", type=str, default="")
-    policy_id: str = click.prompt("Policy ID (optional)", type=str, default="")
-    # home_forecast_provider_id: str = click.prompt("Home forcast provider ID (optional)", type=str, default="")
-    # performance_tracker_id: str = click.prompt("Performace tracker ID (optional)", type=str, default="")
-    notifier_ids_str: str = click.prompt("Notifiers IDs (comma separated, optional)", type=str, default="")
 
-    # To implement in the next release
+    # Select an energy source
+    click.echo("")
+    click.echo(click.style("What Energy Source do you want to use?", fg="yellow"))
+    selected_energy_source: Optional[EnergySource] = select_energy_source(configuration_service, logger)
+    if not selected_energy_source:
+        click.echo(click.style("No energy source selected. Aborting operation.", fg="red"), err=True)
+        click.pause("Press any key to return to the menu...")
+        return
+
+    # Select an optimization policy
+    click.echo("")
+    click.echo(click.style("What Optimization Policy do you want to use?", fg="yellow"))
+    selected_policy: Optional[OptimizationPolicy] = select_optimization_policy(configuration_service)
+    if not selected_policy:
+        click.echo(click.style("No optimization policy selected. Aborting operation.", fg="red"), err=True)
+        click.pause("Press any key to return to the menu...")
+        return
+
+    # Select target miners
+    click.echo("")
+    click.echo(click.style("What Target Miners do you want to control?", fg="yellow"))
+    selected_miners: Union[Optional[Miner], List[Miner]] = select_miner(
+        configuration_service=configuration_service, logger=logger, default_id=None, allow_multiple=True
+    )
+    if not selected_miners:
+        click.echo(click.style("No target miners selected. Aborting operation.", fg="red"), err=True)
+        click.pause("Press any key to return to the menu...")
+        return
+    if isinstance(selected_miners, Miner):
+        selected_miners = [selected_miners]
+
+    # Select notifiers
+    click.echo("")
+    click.echo(click.style("What Notifiers do you want to use?", fg="yellow"))
+    selected_notifiers: Union[Optional[Notifier], List[Notifier]] = select_notifier(
+        configuration_service=configuration_service,
+        logger=logger,
+        default_id=None,
+        allow_multiple=True,
+    )
+    if isinstance(selected_notifiers, Notifier):
+        selected_notifiers = [selected_notifiers]
+
+    # To be implemented in the next release
     home_forecast_provider_id = None
     performance_tracker_id = None
 
     try:
-        target_miner_ids = (
-            [EntityId(UUID(m.strip())) for m in target_miner_ids_str.split(",")] if target_miner_ids_str else []
-        )
-        notifier_ids = [EntityId(UUID(n.strip())) for n in notifier_ids_str.split(",")] if notifier_ids_str else []
+        target_miner_ids = [m.id for m in selected_miners] if selected_miners else []
+        notifier_ids = [n.id for n in selected_notifiers] if selected_notifiers else []
 
         created = configuration_service.create_optimization_unit(
             name=name,
             description=description if description else None,
-            energy_source_id=(EntityId(UUID(energy_source_id)) if energy_source_id else None),
+            energy_source_id=selected_energy_source.id if selected_energy_source else None,
             target_miner_ids=target_miner_ids,
-            policy_id=EntityId(UUID(policy_id)) if policy_id else None,
-            home_forecast_provider_id=(
-                EntityId(UUID(home_forecast_provider_id)) if home_forecast_provider_id else None
-            ),
-            performance_tracker_id=(EntityId(UUID(performance_tracker_id)) if performance_tracker_id else None),
+            policy_id=selected_policy.id if selected_policy else None,
+            home_forecast_provider_id=home_forecast_provider_id,
+            performance_tracker_id=performance_tracker_id,
             notifier_ids=notifier_ids,
         )
         if not created:
@@ -68,9 +114,13 @@ def list_optimization_units(
     else:
         for u in units:
             click.echo(
-                f"-> ID: {u.id}, Name: {u.name}, "
-                f"Description: {u.description if u.description else 'N/A'}, "
-                f"Miner Target: {', '.join(str(u.target_miner_ids)) if u.target_miner_ids else 'N/A'}"
+                "-> "
+                + "Name: "
+                + click.style(f"{u.name}, ", fg="blue")
+                + "ID: "
+                + click.style(f"{u.id}, ", fg="yellow")
+                + "Description: "
+                + click.style(f"{u.description if u.description else 'N/A'}, ", fg="cyan")
             )
 
 
@@ -85,12 +135,670 @@ def handle_list_optimization_units(
     click.pause("Press any key to return to the menu...")
 
 
+def print_optimization_unit_details(
+    optimization_unit: EnergyOptimizationUnit, configuration_service: ConfigurationServiceInterface
+) -> None:
+    """Print details of a specific optimization unit."""
+    energy_source = (
+        configuration_service.get_energy_source(optimization_unit.energy_source_id)
+        if optimization_unit.energy_source_id
+        else None
+    )
+    policy = configuration_service.get_policy(optimization_unit.policy_id) if optimization_unit.policy_id else None
+    miners = (
+        [configuration_service.get_miner(m_id) for m_id in optimization_unit.target_miner_ids]
+        if optimization_unit.target_miner_ids
+        else []
+    )
+    notifiers = (
+        [configuration_service.get_notifier(n_id) for n_id in optimization_unit.notifier_ids]
+        if optimization_unit.notifier_ids
+        else []
+    )
+
+    click.echo("")
+    click.echo("| Name: " + click.style(optimization_unit.name, fg="blue"))
+    click.echo("| ID: " + click.style(optimization_unit.id, fg="yellow"))
+    click.echo(
+        "| Description: "
+        + click.style(
+            optimization_unit.description if optimization_unit.description else "N/A",
+            fg="cyan",
+        )
+    )
+    click.echo(
+        "| Enabled: "
+        + click.style(
+            "Yes" if optimization_unit.is_enabled else "No", fg="green" if optimization_unit.is_enabled else "red"
+        )
+    )
+
+    click.echo("")
+    click.echo("> Energy Source Details:")
+    if energy_source:
+        print_energy_source_details(
+            energy_source=energy_source,
+            configuration_service=configuration_service,
+            show_energy_monitor_details=False,
+            show_forecast_provider_details=False,
+        )
+    else:
+        click.echo(click.style("| No energy source configured.", fg="red"))
+
+    click.echo("> Target Miners Details:")
+    if miners:
+        for miner_idx, miner in enumerate(miners):
+            if miner:
+                click.echo("|---- Miner " + str(miner_idx + 1) + " ----")
+                print_miner_details(
+                    miner=miner,
+                    configuration_service=configuration_service,
+                    show_controller_details=False,
+                    show_external_service=False,
+                )
+                click.echo("--------------------")
+    else:
+        click.echo(click.style("| No target miners configured.", fg="red"))
+
+    click.echo("> Optimization Policy Details:")
+    if policy:
+        print_optimization_policy_details(policy=policy, show_rule_details=False)
+    else:
+        click.echo(click.style("| No optimization policy configured.", fg="red"))
+
+    click.echo("> Notifiers Details:")
+    if notifiers:
+        for notifier_idx, notifier in enumerate(notifiers):
+            if notifier:
+                click.echo("|---- Notifier " + str(notifier_idx + 1) + " ----")
+                print_notifier_details(
+                    notifier=notifier,
+                    configuration_service=configuration_service,
+                    show_external_service=False,
+                    show_optimization_unit_list=False,
+                )
+                click.echo("--------------------")
+    else:
+        click.echo(click.style("| No notifiers configured.", fg="red"))
+
+
+def handle_activate_optimization_unit(
+    optimization_unit: EnergyOptimizationUnit,
+    configuration_service: ConfigurationServiceInterface,
+) -> None:
+    """Activate an optimization unit."""
+    if optimization_unit.is_enabled:
+        click.echo(click.style("The optimization unit is already active.", fg="yellow"))
+        return
+
+    try:
+        configuration_service.activate_optimization_unit(optimization_unit.id)
+        click.echo(click.style("Optimization unit activated successfully.", fg="green"))
+    except Exception as e:
+        click.echo(click.style(f"Error activating optimization unit: {e}", fg="red"))
+
+
+def handle_deactivate_optimization_unit(
+    optimization_unit: EnergyOptimizationUnit,
+    configuration_service: ConfigurationServiceInterface,
+) -> None:
+    """Deactivate an optimization unit."""
+    if not optimization_unit.is_enabled:
+        click.echo(click.style("The optimization unit is already inactive.", fg="yellow"))
+        return
+
+    try:
+        configuration_service.deactivate_optimization_unit(optimization_unit.id)
+        click.echo(click.style("Optimization unit deactivated successfully.", fg="green"))
+    except Exception as e:
+        click.echo(click.style(f"Error deactivating optimization unit: {e}", fg="red"))
+
+
+def update_optimization_unit(
+    optimization_unit: EnergyOptimizationUnit, configuration_service: ConfigurationServiceInterface, logger: LoggerPort
+) -> Optional[EnergyOptimizationUnit]:
+    """Update an optimization unit."""
+    click.echo(click.style("\n--- Update Energy Optimization Unit ---", fg="yellow"))
+
+    name: str = click.prompt(
+        "Name of the energy optimization unit",
+        type=str,
+        default=optimization_unit.name,
+    )
+    description: str = click.prompt(
+        "Description (optional)",
+        type=str,
+        default=optimization_unit.description if optimization_unit.description else "",
+    )
+
+    new_optimization_unit: EnergyOptimizationUnit = EnergyOptimizationUnit()
+    new_optimization_unit.name = name
+    new_optimization_unit.description = description
+    new_optimization_unit.is_enabled = optimization_unit.is_enabled
+    new_optimization_unit.energy_source_id = optimization_unit.energy_source_id
+    new_optimization_unit.target_miner_ids = optimization_unit.target_miner_ids
+    new_optimization_unit.policy_id = optimization_unit.policy_id
+    new_optimization_unit.notifier_ids = optimization_unit.notifier_ids
+    new_optimization_unit.home_forecast_provider_id = optimization_unit.home_forecast_provider_id
+    new_optimization_unit.performance_tracker_id = optimization_unit.performance_tracker_id
+
+    click.echo("\nDo you want to change the energy source?")
+    change_energy_source: bool = click.confirm("Change energy source?", default=True, prompt_suffix="")
+    if change_energy_source:
+        selected_energy_source: Optional[EnergySource] = select_energy_source(configuration_service, logger)
+        if selected_energy_source is None:
+            click.echo(click.style("Invalid energy source selected. Aborting operation.", fg="red"), err=True)
+            return None
+        # Update energy source
+        new_optimization_unit.energy_source_id = selected_energy_source.id
+
+    click.echo("\nDo you want to change the optimization policy?")
+    change_policy: bool = click.confirm("Change optimization policy?", default=True, prompt_suffix="")
+    if change_policy:
+        selected_policy: Optional[OptimizationPolicy] = select_optimization_policy(configuration_service)
+        if selected_policy is None:
+            click.echo(click.style("Invalid optimization policy selected. Aborting operation.", fg="red"), err=True)
+            return None
+        # Update policy
+        new_optimization_unit.policy_id = selected_policy.id
+
+    click.echo("\nDo you want to change the target miners?")
+    change_miners: bool = click.confirm("Change target miners?", default=True, prompt_suffix="")
+    if change_miners:
+        selected_miners: Union[Optional[Miner], List[Miner]] = select_miner(
+            configuration_service=configuration_service,
+            logger=logger,
+            default_id=None,
+            allow_multiple=True,
+        )
+        if not selected_miners:
+            click.echo(click.style("No target miners selected. Aborting operation.", fg="red"), err=True)
+            return None
+        if isinstance(selected_miners, Miner):
+            selected_miners = [selected_miners]
+        new_optimization_unit.target_miner_ids = [m.id for m in selected_miners]
+
+    click.echo("\nDo you want to change the notifiers?")
+    change_notifiers: bool = click.confirm("Change notifiers?", default=True, prompt_suffix="")
+    if change_notifiers:
+        selected_notifiers: Union[Optional[Notifier], List[Notifier]] = select_notifier(
+            configuration_service=configuration_service,
+            logger=logger,
+            default_id=None,
+            allow_multiple=True,
+        )
+        if isinstance(selected_notifiers, Notifier):
+            selected_notifiers = [selected_notifiers]
+        new_optimization_unit.notifier_ids = [n.id for n in selected_notifiers] if selected_notifiers else []
+
+    # Home forecast provider and performance tracker updates to be implemented in the next release
+
+    try:
+        updated = configuration_service.update_optimization_unit(
+            unit_id=optimization_unit.id,
+            name=new_optimization_unit.name,
+            description=new_optimization_unit.description,
+            energy_source_id=new_optimization_unit.energy_source_id,
+            target_miner_ids=new_optimization_unit.target_miner_ids,
+            policy_id=new_optimization_unit.policy_id,
+            home_forecast_provider_id=new_optimization_unit.home_forecast_provider_id,
+            performance_tracker_id=new_optimization_unit.performance_tracker_id,
+            notifier_ids=new_optimization_unit.notifier_ids,
+            is_enabled=new_optimization_unit.is_enabled,
+        )
+        click.echo(
+            click.style(
+                f"Energy Optimization Unit '{updated.name}' successfully updated.",
+                fg="green",
+            )
+        )
+    except Exception as e:
+        updated = None
+        logger.error(f"Error updating optimization unit: {e}")
+        click.echo(click.style(f"Error updating optimization unit: {e}", fg="red"), err=True)
+        return None
+    finally:
+        click.pause("Press any key to return to the menu...")
+
+    return updated
+
+
+def delete_single_optimization_unit(
+    optimization_unit: EnergyOptimizationUnit,
+    configuration_service: ConfigurationServiceInterface,
+) -> bool:
+    """Delete a single optimization unit."""
+    confirm_delete: bool = click.confirm(
+        f"Are you sure you want to delete the optimization unit '{optimization_unit.name}' (ID: {optimization_unit.id})?",
+        default=False,
+        prompt_suffix="",
+    )
+    if not confirm_delete:
+        click.echo(click.style("Deletion cancelled.", fg="yellow"))
+        return False
+
+    try:
+        configuration_service.remove_optimization_unit(optimization_unit.id)
+        click.echo(click.style("Optimization unit deleted successfully.", fg="green"))
+        return True
+    except Exception as e:
+        click.echo(click.style(f"Error deleting optimization unit: {e}", fg="red"))
+        return False
+
+
+def manage_assign_energy_source(
+    optimization_unit: EnergyOptimizationUnit,
+    configuration_service: ConfigurationServiceInterface,
+    logger: LoggerPort,
+) -> None:
+    """Assign an energy source to an optimization unit."""
+    click.echo(click.style("\n--- Assign Energy Source to Optimization Unit ---", fg="yellow"))
+
+    selected_energy_source: Optional[EnergySource] = select_energy_source(configuration_service, logger)
+    if not selected_energy_source:
+        click.echo(click.style("No energy source selected. Aborting operation.", fg="red"), err=True)
+        click.pause("Press any key to return to the menu...")
+        return
+
+    try:
+        configuration_service.assign_energy_source_to_optimization_unit(
+            unit_id=optimization_unit.id, energy_source_id=selected_energy_source.id
+        )
+        click.echo(click.style(f"Energy source '{selected_energy_source.name}' assigned successfully.", fg="green"))
+    except Exception as e:
+        logger.error(f"Error assigning energy source: {e}")
+        click.echo(click.style(f"Error assigning energy source: {e}", fg="red"))
+    click.pause("Press any key to return to the menu...")
+
+
+def manage_assign_optimization_policy(
+    optimization_unit: EnergyOptimizationUnit,
+    configuration_service: ConfigurationServiceInterface,
+) -> None:
+    """Assign an optimization policy to an optimization unit."""
+    click.echo(click.style("\n--- Assign Optimization Policy to Optimization Unit ---", fg="yellow"))
+
+    selected_policy: Optional[OptimizationPolicy] = select_optimization_policy(configuration_service)
+    if not selected_policy:
+        click.echo(click.style("No optimization policy selected. Aborting operation.", fg="red"), err=True)
+        click.pause("Press any key to return to the menu...")
+        return
+
+    try:
+        configuration_service.assign_policy_to_optimization_unit(
+            unit_id=optimization_unit.id, policy_id=selected_policy.id
+        )
+        click.echo(click.style(f"Optimization policy '{selected_policy.name}' assigned successfully.", fg="green"))
+    except Exception as e:
+        click.echo(click.style(f"Error assigning optimization policy: {e}", fg="red"))
+    click.pause("Press any key to return to the menu...")
+
+
+def manage_assign_target_miners(
+    optimization_unit: EnergyOptimizationUnit,
+    configuration_service: ConfigurationServiceInterface,
+    logger: LoggerPort,
+) -> None:
+    """Assign target miners to an optimization unit."""
+    click.echo(click.style("\n--- Assign Target Miners to Optimization Unit ---", fg="yellow"))
+
+    selected_miners: Union[Optional[Miner], List[Miner]] = select_miner(
+        configuration_service=configuration_service, logger=logger, default_id=None, allow_multiple=True
+    )
+    if not selected_miners:
+        click.echo(click.style("No target miners selected. Aborting operation.", fg="red"), err=True)
+        click.pause("Press any key to return to the menu...")
+        return
+    if isinstance(selected_miners, Miner):
+        selected_miners = [selected_miners]
+
+    try:
+        target_miner_ids = [m.id for m in selected_miners]
+        configuration_service.assign_miners_to_optimization_unit(
+            unit_id=optimization_unit.id, miner_ids=target_miner_ids
+        )
+        click.echo(click.style(f"{len(selected_miners)} Target miners assigned successfully.", fg="green"))
+    except Exception as e:
+        logger.error(f"Error assigning target miners: {e}")
+        click.echo(click.style(f"Error assigning target miners: {e}", fg="red"))
+    click.pause("Press any key to return to the menu...")
+
+
+def manage_add_target_miner(
+    optimization_unit: EnergyOptimizationUnit,
+    configuration_service: ConfigurationServiceInterface,
+    logger: LoggerPort,
+) -> None:
+    """Add a target miner to an optimization unit."""
+    click.echo(click.style("\n--- Add Target Miner to Optimization Unit ---", fg="yellow"))
+
+    selected_miner: Union[Optional[Miner], List[Miner]] = select_miner(
+        configuration_service=configuration_service,
+        logger=logger,
+        default_id=None,
+        allow_multiple=False,
+        exclude_ids=optimization_unit.target_miner_ids,
+    )
+    if not selected_miner:
+        click.echo(click.style("No target miner selected. Aborting operation.", fg="red"), err=True)
+        click.pause("Press any key to return to the menu...")
+        return
+    if isinstance(selected_miner, list):
+        selected_miner = selected_miner[0]
+
+    # Check if the miner already exists in the optimization unit
+    if selected_miner.id in optimization_unit.target_miner_ids:
+        click.echo(
+            click.style(
+                f"Target miner '{selected_miner.name}' is already assigned to this optimization unit.", fg="red"
+            )
+        )
+        click.pause("Press any key to return to the menu...")
+        return
+
+    try:
+        configuration_service.add_miner_to_optimization_unit(unit_id=optimization_unit.id, miner_id=selected_miner.id)
+        click.echo(click.style(f"Target miner '{selected_miner.name}' added successfully.", fg="green"))
+    except Exception as e:
+        logger.error(f"Error adding target miner: {e}")
+        click.echo(click.style(f"Error adding target miner: {e}", fg="red"))
+    click.pause("Press any key to return to the menu...")
+
+
+def manage_remove_target_miner(
+    optimization_unit: EnergyOptimizationUnit,
+    configuration_service: ConfigurationServiceInterface,
+    logger: LoggerPort,
+) -> None:
+    """Remove a target miner from an optimization unit."""
+    click.echo(click.style("\n--- Remove Target Miner from Optimization Unit ---", fg="yellow"))
+
+    selected_miner: Union[Optional[Miner], List[Miner]] = select_miner(
+        configuration_service=configuration_service,
+        logger=logger,
+        default_id=None,
+        allow_multiple=False,
+        only_ids=optimization_unit.target_miner_ids,
+    )
+    if not selected_miner:
+        click.echo(click.style("No target miner selected. Aborting operation.", fg="red"), err=True)
+        click.pause("Press any key to return to the menu...")
+        return
+    if isinstance(selected_miner, list):
+        selected_miner = selected_miner[0]
+
+    try:
+        configuration_service.remove_miner_from_optimization_unit(
+            unit_id=optimization_unit.id, miner_id=selected_miner.id
+        )
+        click.echo(click.style(f"Target miner '{selected_miner.name}' removed successfully.", fg="green"))
+    except Exception as e:
+        logger.error(f"Error removing target miner: {e}")
+        click.echo(click.style(f"Error removing target miner: {e}", fg="red"))
+    click.pause("Press any key to return to the menu...")
+
+
+def manage_assign_notifiers(
+    optimization_unit: EnergyOptimizationUnit,
+    configuration_service: ConfigurationServiceInterface,
+    logger: LoggerPort,
+) -> None:
+    """Assign notifiers to an optimization unit."""
+    click.echo(click.style("\n--- Assign Notifiers to Optimization Unit ---", fg="yellow"))
+
+    selected_notifiers: Union[Optional[Notifier], List[Notifier]] = select_notifier(
+        configuration_service=configuration_service,
+        logger=logger,
+        default_id=None,
+        allow_multiple=True,
+    )
+    if isinstance(selected_notifiers, Notifier):
+        selected_notifiers = [selected_notifiers]
+
+    try:
+        notifier_ids = [n.id for n in selected_notifiers] if selected_notifiers else []
+        configuration_service.assign_notifiers_to_optimization_unit(
+            unit_id=optimization_unit.id, notifier_ids=notifier_ids
+        )
+        click.echo(click.style(f"{len(notifier_ids)} Notifiers assigned successfully.", fg="green"))
+    except Exception as e:
+        logger.error(f"Error assigning notifiers: {e}")
+        click.echo(click.style(f"Error assigning notifiers: {e}", fg="red"))
+    click.pause("Press any key to return to the menu...")
+
+
+def manage_add_notifier(
+    optimization_unit: EnergyOptimizationUnit,
+    configuration_service: ConfigurationServiceInterface,
+    logger: LoggerPort,
+) -> None:
+    """Add a notifier to an optimization unit."""
+    click.echo(click.style("\n--- Add Notifier to Optimization Unit ---", fg="yellow"))
+
+    selected_notifier: Union[Optional[Notifier], List[Notifier]] = select_notifier(
+        configuration_service=configuration_service,
+        logger=logger,
+        default_id=None,
+        allow_multiple=False,
+        exclude_ids=optimization_unit.notifier_ids,
+    )
+    if not selected_notifier:
+        click.echo(click.style("No notifier selected. Aborting operation.", fg="red"), err=True)
+        click.pause("Press any key to return to the menu...")
+        return
+    if isinstance(selected_notifier, list):
+        selected_notifier = selected_notifier[0]
+
+    try:
+        configuration_service.add_notifier_to_optimization_unit(
+            unit_id=optimization_unit.id, notifier_id=selected_notifier.id
+        )
+        click.echo(click.style(f"Notifier '{selected_notifier.name}' added successfully.", fg="green"))
+    except Exception as e:
+        logger.error(f"Error adding notifier: {e}")
+        click.echo(click.style(f"Error adding notifier: {e}", fg="red"))
+    click.pause("Press any key to return to the menu...")
+
+
+def manage_remove_notifier(
+    optimization_unit: EnergyOptimizationUnit,
+    configuration_service: ConfigurationServiceInterface,
+    logger: LoggerPort,
+) -> None:
+    """Remove a notifier from an optimization unit."""
+    click.echo(click.style("\n--- Remove Notifier from Optimization Unit ---", fg="yellow"))
+
+    selected_notifier: Union[Optional[Notifier], List[Notifier]] = select_notifier(
+        configuration_service=configuration_service,
+        logger=logger,
+        default_id=None,
+        allow_multiple=False,
+        only_ids=optimization_unit.notifier_ids,
+    )
+    if isinstance(selected_notifier, list):
+        selected_notifier = selected_notifier[0]
+
+    if not selected_notifier:
+        click.echo(click.style("No notifier selected. Aborting operation.", fg="red"), err=True)
+        click.pause("Press any key to return to the menu...")
+        return
+
+    try:
+        configuration_service.remove_notifier_from_optimization_unit(
+            unit_id=optimization_unit.id, notifier_id=selected_notifier.id
+        )
+        click.echo(click.style(f"Notifier '{selected_notifier.name}' removed successfully.", fg="green"))
+    except Exception as e:
+        logger.error(f"Error removing notifier: {e}")
+        click.echo(click.style(f"Error removing notifier: {e}", fg="red"))
+    click.pause("Press any key to return to the menu...")
+
+
+def manage_single_optimization_unit_menu(
+    unit_id: EntityId, configuration_service: ConfigurationServiceInterface, logger: LoggerPort
+) -> str:
+    """Menu for managing a single optimization unit."""
+    while True:
+        # Refresh optimization unit data
+        optimization_unit = configuration_service.get_optimization_unit(unit_id)
+        if not optimization_unit:
+            click.echo(click.style("Optimization unit not found. Returning to previous menu.", fg="red"))
+            return "b"
+
+        click.clear()
+        click.echo(
+            click.style(
+                f"=== Manage Optimization Unit: {optimization_unit.name} ===",
+                fg="yellow",
+            )
+        )
+
+        print_optimization_unit_details(optimization_unit, configuration_service)
+
+        click.echo("")
+        click.echo("")
+
+        click.echo("1. Activate optimization unit")
+        click.echo("2. Deactivate optimization unit")
+        click.echo("3. Update optimization unit")
+        click.echo("4. Delete optimization unit")
+        click.echo("")
+        click.echo("5. Assign Energy Source")
+        click.echo("6. Assign Optimization Policy")
+        click.echo("7. Assign Target Miners")
+        click.echo("8. Add a Target Miner")
+        click.echo("9. Remove a Target Miner")
+        click.echo("10. Assign Notifiers")
+        click.echo("11. Add a Notifier")
+        click.echo("12. Remove a Notifier")
+        click.echo("")
+        click.echo("b. Back to optimization unit menu")
+        click.echo("q. Close application")
+        click.echo("-----------------")
+
+        choice: str = click.prompt("Choose an option", type=str, default="b")
+        choice = choice.strip().lower()
+
+        if choice == "1":
+            handle_activate_optimization_unit(optimization_unit, configuration_service)
+            continue
+        elif choice == "2":
+            handle_deactivate_optimization_unit(optimization_unit, configuration_service)
+            continue
+        elif choice == "3":
+            updated_optimization_unit = update_optimization_unit(optimization_unit, configuration_service, logger)
+            optimization_unit = updated_optimization_unit or optimization_unit
+            continue
+        elif choice == "4":
+            delete_status = delete_single_optimization_unit(optimization_unit, configuration_service)
+            if delete_status:
+                return "b"
+            continue
+        elif choice == "5":
+            manage_assign_energy_source(optimization_unit, configuration_service, logger)
+            continue
+        elif choice == "6":
+            manage_assign_optimization_policy(optimization_unit, configuration_service)
+            continue
+        elif choice == "7":
+            manage_assign_target_miners(optimization_unit, configuration_service, logger)
+            continue
+        elif choice == "8":
+            manage_add_target_miner(optimization_unit, configuration_service, logger)
+            continue
+        elif choice == "9":
+            manage_remove_target_miner(optimization_unit, configuration_service, logger)
+            continue
+        elif choice == "10":
+            manage_assign_notifiers(optimization_unit, configuration_service, logger)
+            continue
+        elif choice == "11":
+            manage_add_notifier(optimization_unit, configuration_service, logger)
+            continue
+        elif choice == "12":
+            manage_remove_notifier(optimization_unit, configuration_service, logger)
+            continue
+        elif choice == "b":
+            break
+        elif choice == "q":
+            break
+        else:
+            click.echo(click.style("Invalid choice. Try again.", fg="red"))
+            click.pause("Press any key to return to the menu...")
+
+    return choice
+
+
+def select_optimization_unit(
+    configuration_service: ConfigurationServiceInterface, logger: LoggerPort, default_id: Optional[EntityId] = None
+) -> Optional[EnergyOptimizationUnit]:
+    """Select an optimization unit."""
+    click.echo(click.style("\n--- Select an Energy Optimization Unit ---", fg="yellow"))
+
+    units = configuration_service.list_optimization_units()
+    if not units:
+        click.echo(click.style("No optimization units configured.", fg="red"))
+        return None
+
+    default_idx = ""
+    for idx, unit in enumerate(units):
+        click.echo(
+            f"{idx}. "
+            + "Name: "
+            + click.style(f"{unit.name}, ", fg="blue")
+            + "ID: "
+            + click.style(f"{unit.id}, ", fg="yellow")
+            + "Description: "
+            + click.style(f"{unit.description if unit.description else 'N/A'}, ", fg="cyan")
+            + "Enabled: "
+            + click.style(f"{'Yes' if unit.is_enabled else 'No'}", fg="green" if unit.is_enabled else "red")
+        )
+
+        if default_id:
+            if unit.id == default_id:
+                default_idx = str(idx)
+
+    click.echo("\nb. Back to menu\n")
+
+    unit_idx: str = click.prompt("Choose an optimization unit index", type=str, default=default_idx)
+    unit_idx = unit_idx.strip().lower()
+    if unit_idx == "b":
+        return None
+
+    if not unit_idx.isdigit() or int(unit_idx) < 0 or int(unit_idx) >= len(units):
+        click.echo(click.style("Invalid optimization unit index selected.", fg="red"))
+        return None
+
+    selected_unit = units[int(unit_idx)]
+    return selected_unit
+
+
+def handle_manage_optimization_unit(
+    configuration_service: ConfigurationServiceInterface,
+    logger: LoggerPort,
+) -> str:
+    """Menu to manage a specific optimization unit."""
+    selected_optimization_unit = select_optimization_unit(configuration_service, logger)
+
+    if not selected_optimization_unit:
+        click.echo(click.style("No optimization unit selected. Aborting.", fg="red"))
+        return "b"
+
+    choice = manage_single_optimization_unit_menu(
+        unit_id=selected_optimization_unit.id, configuration_service=configuration_service, logger=logger
+    )
+
+    return choice
+
+
 def optimization_unit_menu(configuration_service: ConfigurationServiceInterface, logger: LoggerPort) -> str:
     """Menu for managing Optimization Units."""
     while True:
         click.echo("\n" + click.style("--- MENU ENERGY OPTIMIZATION UNIT ---", fg="yellow", bold=True))
-        click.echo("1. Create new Energy Optimization Unit")
-        click.echo("2. List all configured Energy Optimization Units")
+        click.echo("1. Add an Energy Optimization Unit")
+        click.echo("2. List all Energy Optimization Units")
+        click.echo("3. Manage an Energy Optimization Unit")
+        click.echo("")
         click.echo("b. Back to main menu")
         click.echo("q. Close application")
         click.echo("---------------------------------")
@@ -101,9 +809,13 @@ def optimization_unit_menu(configuration_service: ConfigurationServiceInterface,
         click.clear()
 
         if choice == "1":
-            handle_create_optimization_unit(configuration_service=configuration_service, logger=logger)
+            handle_add_optimization_unit(configuration_service=configuration_service, logger=logger)
         elif choice == "2":
             handle_list_optimization_units(configuration_service=configuration_service)
+        elif choice == "3":
+            sub_choice = handle_manage_optimization_unit(configuration_service=configuration_service, logger=logger)
+            if sub_choice == "q":
+                break
         elif choice == "b":
             break
         elif choice == "q":

--- a/edge_mining/adapters/domain/optimization_unit/cli/commands.py
+++ b/edge_mining/adapters/domain/optimization_unit/cli/commands.py
@@ -337,7 +337,7 @@ def update_optimization_unit(
             selected_notifiers = [selected_notifiers]
         new_optimization_unit.notifier_ids = [n.id for n in selected_notifiers] if selected_notifiers else []
 
-    # Home forecast provider and performance tracker updates to be implemented in the next release
+    # Home forecast provider and performance tracker updates will be implemented in the next release
 
     try:
         updated = configuration_service.update_optimization_unit(
@@ -519,6 +519,11 @@ def manage_remove_target_miner(
     """Remove a target miner from an optimization unit."""
     click.echo(click.style("\n--- Remove Target Miner from Optimization Unit ---", fg="yellow"))
 
+    if not optimization_unit.target_miner_ids:
+        click.echo(click.style("No target miners assigned to this optimization unit.", fg="red"))
+        click.pause("Press any key to return to the menu...")
+        return
+
     selected_miner: Union[Optional[Miner], List[Miner]] = select_miner(
         configuration_service=configuration_service,
         logger=logger,
@@ -613,6 +618,11 @@ def manage_remove_notifier(
 ) -> None:
     """Remove a notifier from an optimization unit."""
     click.echo(click.style("\n--- Remove Notifier from Optimization Unit ---", fg="yellow"))
+
+    if not optimization_unit.notifier_ids:
+        click.echo(click.style("No notifiers assigned to this optimization unit.", fg="red"))
+        click.pause("Press any key to return to the menu...")
+        return
 
     selected_notifier: Union[Optional[Notifier], List[Notifier]] = select_notifier(
         configuration_service=configuration_service,

--- a/edge_mining/adapters/domain/optimization_unit/cli/commands.py
+++ b/edge_mining/adapters/domain/optimization_unit/cli/commands.py
@@ -229,6 +229,7 @@ def handle_activate_optimization_unit(
     """Activate an optimization unit."""
     if optimization_unit.is_enabled:
         click.echo(click.style("The optimization unit is already active.", fg="yellow"))
+        click.pause("Press any key to return to the menu...")
         return
 
     try:
@@ -236,6 +237,8 @@ def handle_activate_optimization_unit(
         click.echo(click.style("Optimization unit activated successfully.", fg="green"))
     except Exception as e:
         click.echo(click.style(f"Error activating optimization unit: {e}", fg="red"))
+
+    click.pause("Press any key to return to the menu...")
 
 
 def handle_deactivate_optimization_unit(
@@ -245,6 +248,7 @@ def handle_deactivate_optimization_unit(
     """Deactivate an optimization unit."""
     if not optimization_unit.is_enabled:
         click.echo(click.style("The optimization unit is already inactive.", fg="yellow"))
+        click.pause("Press any key to return to the menu...")
         return
 
     try:
@@ -252,6 +256,8 @@ def handle_deactivate_optimization_unit(
         click.echo(click.style("Optimization unit deactivated successfully.", fg="green"))
     except Exception as e:
         click.echo(click.style(f"Error deactivating optimization unit: {e}", fg="red"))
+
+    click.pause("Press any key to return to the menu...")
 
 
 def update_optimization_unit(

--- a/edge_mining/adapters/domain/optimization_unit/cli/commands.py
+++ b/edge_mining/adapters/domain/optimization_unit/cli/commands.py
@@ -18,9 +18,13 @@ def handle_create_optimization_unit(configuration_service: ConfigurationServiceI
     energy_source_id: str = click.prompt("Energy source ID (optional)", type=str, default="")
     target_miner_ids_str: str = click.prompt("Miner target IDs (comma separated, optional)", type=str, default="")
     policy_id: str = click.prompt("Policy ID (optional)", type=str, default="")
-    home_forecast_provider_id: str = click.prompt("Home forcast provider ID (optional)", type=str, default="")
-    performance_tracker_id: str = click.prompt("Performace tracker ID (optional)", type=str, default="")
+    # home_forecast_provider_id: str = click.prompt("Home forcast provider ID (optional)", type=str, default="")
+    # performance_tracker_id: str = click.prompt("Performace tracker ID (optional)", type=str, default="")
     notifier_ids_str: str = click.prompt("Notifiers IDs (comma separated, optional)", type=str, default="")
+
+    # To implement in the next release
+    home_forecast_provider_id = None
+    performance_tracker_id = None
 
     try:
         target_miner_ids = (

--- a/edge_mining/adapters/domain/optimization_unit/fast_api/__init__.py
+++ b/edge_mining/adapters/domain/optimization_unit/fast_api/__init__.py
@@ -1,0 +1,1 @@
+"""Adapters API for the Energy Optimization Unit domain."""

--- a/edge_mining/adapters/domain/optimization_unit/fast_api/router.py
+++ b/edge_mining/adapters/domain/optimization_unit/fast_api/router.py
@@ -1,0 +1,418 @@
+"""API Router for optimization unit domain."""
+
+import uuid
+from typing import Annotated, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from edge_mining.adapters.domain.optimization_unit.schemas import (
+    EnergyOptimizationUnitCreateSchema,
+    EnergyOptimizationUnitSchema,
+    EnergyOptimizationUnitUpdateSchema,
+)
+
+# Import dependency injection setup functions
+from edge_mining.adapters.infrastructure.api.setup import get_config_service
+from edge_mining.application.interfaces import ConfigurationServiceInterface
+from edge_mining.domain.common import EntityId
+from edge_mining.domain.optimization_unit.aggregate_roots import EnergyOptimizationUnit
+from edge_mining.domain.optimization_unit.exceptions import (
+    OptimizationUnitAlreadyExistsError,
+    OptimizationUnitConfigurationError,
+    OptimizationUnitNotFoundError,
+)
+
+router = APIRouter()
+
+
+@router.get("/optimization-units", response_model=List[EnergyOptimizationUnitSchema])
+async def get_optimization_units_list(
+    config_service: Annotated[ConfigurationServiceInterface, Depends(get_config_service)],
+) -> List[EnergyOptimizationUnitSchema]:
+    """Get a list of all configured optimization units."""
+    try:
+        optimization_units: List[EnergyOptimizationUnit] = config_service.list_optimization_units()
+
+        # Convert to optimization unit schema
+        optimization_unit_schemas: List[EnergyOptimizationUnitSchema] = []
+
+        for optimization_unit in optimization_units:
+            optimization_unit_schemas.append(EnergyOptimizationUnitSchema.from_model(optimization_unit))
+
+        return optimization_unit_schemas
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.post("/optimization-units", response_model=EnergyOptimizationUnitSchema)
+async def add_optimization_unit(
+    optimization_unit_data: EnergyOptimizationUnitCreateSchema,
+    config_service: Annotated[ConfigurationServiceInterface, Depends(get_config_service)],
+) -> EnergyOptimizationUnitSchema:
+    """Add a new optimization unit."""
+    try:
+        # Convert to domain model
+        optimization_unit_to_add: EnergyOptimizationUnit = optimization_unit_data.to_model()
+
+        # Add the optimization unit
+        created_unit = config_service.create_optimization_unit(
+            name=optimization_unit_to_add.name,
+            description=optimization_unit_to_add.description,
+            policy_id=optimization_unit_to_add.policy_id,
+            target_miner_ids=optimization_unit_to_add.target_miner_ids,
+            energy_source_id=optimization_unit_to_add.energy_source_id,
+            home_forecast_provider_id=optimization_unit_to_add.home_forecast_provider_id,
+            performance_tracker_id=optimization_unit_to_add.performance_tracker_id,
+            notifier_ids=optimization_unit_to_add.notifier_ids,
+        )
+
+        if created_unit is None:
+            raise HTTPException(status_code=500, detail="Failed to create optimization unit")
+
+        response = EnergyOptimizationUnitSchema.from_model(created_unit)
+        return response
+    except OptimizationUnitAlreadyExistsError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except OptimizationUnitConfigurationError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.get("/optimization-units/{unit_id}", response_model=EnergyOptimizationUnitSchema)
+async def get_optimization_unit(
+    unit_id: EntityId,
+    config_service: Annotated[ConfigurationServiceInterface, Depends(get_config_service)],
+) -> EnergyOptimizationUnitSchema:
+    """Get details of a specific optimization unit."""
+    try:
+        optimization_unit: Optional[EnergyOptimizationUnit] = config_service.get_optimization_unit(unit_id)
+
+        if optimization_unit is None:
+            raise OptimizationUnitNotFoundError(f"Optimization Unit with ID {unit_id} not found")
+
+        return EnergyOptimizationUnitSchema.from_model(optimization_unit)
+    except OptimizationUnitNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.put("/optimization-units/{unit_id}", response_model=EnergyOptimizationUnitSchema)
+async def update_optimization_unit(
+    unit_id: EntityId,
+    optimization_unit_update: EnergyOptimizationUnitUpdateSchema,
+    config_service: Annotated[ConfigurationServiceInterface, Depends(get_config_service)],
+) -> EnergyOptimizationUnitSchema:
+    """Update an existing optimization unit."""
+    try:
+        optimization_unit = config_service.get_optimization_unit(unit_id)
+
+        if optimization_unit is None:
+            raise OptimizationUnitNotFoundError(f"Optimization Unit with ID {unit_id} not found")
+
+        # Parse entity IDs
+        policy_id: Optional[EntityId] = None
+        if optimization_unit_update.policy_id:
+            policy_id = EntityId(uuid.UUID(optimization_unit_update.policy_id))
+
+        target_miner_ids: List[EntityId] = []
+        if optimization_unit_update.target_miner_ids:
+            target_miner_ids = [EntityId(uuid.UUID(miner_id)) for miner_id in optimization_unit_update.target_miner_ids]
+
+        energy_source_id: Optional[EntityId] = None
+        if optimization_unit_update.energy_source_id:
+            energy_source_id = EntityId(uuid.UUID(optimization_unit_update.energy_source_id))
+
+        home_forecast_provider_id: Optional[EntityId] = None
+        if optimization_unit_update.home_forecast_provider_id:
+            home_forecast_provider_id = EntityId(uuid.UUID(optimization_unit_update.home_forecast_provider_id))
+
+        performance_tracker_id: Optional[EntityId] = None
+        if optimization_unit_update.performance_tracker_id:
+            performance_tracker_id = EntityId(uuid.UUID(optimization_unit_update.performance_tracker_id))
+
+        notifier_ids: List[EntityId] = []
+        if optimization_unit_update.notifier_ids:
+            notifier_ids = [EntityId(uuid.UUID(notifier_id)) for notifier_id in optimization_unit_update.notifier_ids]
+
+        # Update the optimization unit
+        updated_unit = config_service.update_optimization_unit(
+            unit_id=unit_id,
+            name=optimization_unit_update.name or "",
+            description=optimization_unit_update.description,
+            policy_id=policy_id,
+            target_miner_ids=target_miner_ids,
+            energy_source_id=energy_source_id,
+            home_forecast_provider_id=home_forecast_provider_id,
+            performance_tracker_id=performance_tracker_id,
+            notifier_ids=notifier_ids,
+        )
+
+        response = EnergyOptimizationUnitSchema.from_model(updated_unit)
+
+        return response
+    except OptimizationUnitNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.delete("/optimization-units/{unit_id}", response_model=EnergyOptimizationUnitSchema)
+async def delete_optimization_unit(
+    unit_id: EntityId,
+    config_service: Annotated[ConfigurationServiceInterface, Depends(get_config_service)],
+) -> EnergyOptimizationUnitSchema:
+    """Remove an optimization unit."""
+    try:
+        deleted_unit = config_service.remove_optimization_unit(unit_id)
+
+        response = EnergyOptimizationUnitSchema.from_model(deleted_unit)
+
+        return response
+    except OptimizationUnitNotFoundError as e:
+        raise HTTPException(status_code=404, detail="Optimization Unit not found") from e
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.post("/optimization-units/{unit_id}/enable", response_model=EnergyOptimizationUnitSchema)
+async def enable_optimization_unit(
+    unit_id: EntityId,
+    config_service: Annotated[ConfigurationServiceInterface, Depends(get_config_service)],
+) -> EnergyOptimizationUnitSchema:
+    """Enable an optimization unit."""
+    try:
+        optimization_unit = config_service.get_optimization_unit(unit_id)
+
+        if optimization_unit is None:
+            raise OptimizationUnitNotFoundError(f"Optimization Unit with ID {unit_id} not found")
+
+        enabled_unit = config_service.activate_optimization_unit(unit_id)
+
+        response = EnergyOptimizationUnitSchema.from_model(enabled_unit)
+
+        return response
+    except OptimizationUnitNotFoundError as e:
+        raise HTTPException(status_code=404, detail="Optimization Unit not found") from e
+    except OptimizationUnitConfigurationError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.post("/optimization-units/{unit_id}/disable", response_model=EnergyOptimizationUnitSchema)
+async def disable_optimization_unit(
+    unit_id: EntityId,
+    config_service: Annotated[ConfigurationServiceInterface, Depends(get_config_service)],
+) -> EnergyOptimizationUnitSchema:
+    """Disable an optimization unit."""
+    try:
+        optimization_unit = config_service.get_optimization_unit(unit_id)
+
+        if optimization_unit is None:
+            raise OptimizationUnitNotFoundError(f"Optimization Unit with ID {unit_id} not found")
+
+        disabled_unit = config_service.deactivate_optimization_unit(unit_id)
+
+        response = EnergyOptimizationUnitSchema.from_model(disabled_unit)
+
+        return response
+    except OptimizationUnitNotFoundError as e:
+        raise HTTPException(status_code=404, detail="Optimization Unit not found") from e
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.post("/optimization-units/{unit_id}/energy-source", response_model=EnergyOptimizationUnitSchema)
+async def assign_energy_source(
+    unit_id: EntityId,
+    energy_source_id: EntityId,
+    config_service: Annotated[ConfigurationServiceInterface, Depends(get_config_service)],
+) -> EnergyOptimizationUnitSchema:
+    """Assign an energy source to an optimization unit."""
+    try:
+        optimization_unit = config_service.get_optimization_unit(unit_id)
+
+        if optimization_unit is None:
+            raise OptimizationUnitNotFoundError(f"Optimization Unit with ID {unit_id} not found")
+
+        updated_unit = config_service.assign_energy_source_to_optimization_unit(unit_id, energy_source_id)
+
+        response = EnergyOptimizationUnitSchema.from_model(updated_unit)
+
+        return response
+    except OptimizationUnitNotFoundError as e:
+        raise HTTPException(status_code=404, detail="Optimization Unit not found") from e
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.post("/optimization-units/{unit_id}/policy", response_model=EnergyOptimizationUnitSchema)
+async def assign_policy(
+    unit_id: EntityId,
+    policy_id: EntityId,
+    config_service: Annotated[ConfigurationServiceInterface, Depends(get_config_service)],
+) -> EnergyOptimizationUnitSchema:
+    """Assign an optimization policy to an optimization unit."""
+    try:
+        optimization_unit = config_service.get_optimization_unit(unit_id)
+
+        if optimization_unit is None:
+            raise OptimizationUnitNotFoundError(f"Optimization Unit with ID {unit_id} not found")
+
+        updated_unit = config_service.assign_policy_to_optimization_unit(unit_id, policy_id)
+
+        response = EnergyOptimizationUnitSchema.from_model(updated_unit)
+
+        return response
+    except OptimizationUnitNotFoundError as e:
+        raise HTTPException(status_code=404, detail="Optimization Unit not found") from e
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.post("/optimization-units/{unit_id}/miners", response_model=EnergyOptimizationUnitSchema)
+async def assign_miners(
+    unit_id: EntityId,
+    miner_ids: List[EntityId],
+    config_service: Annotated[ConfigurationServiceInterface, Depends(get_config_service)],
+) -> EnergyOptimizationUnitSchema:
+    """Assign target miners to an optimization unit."""
+    try:
+        optimization_unit = config_service.get_optimization_unit(unit_id)
+
+        if optimization_unit is None:
+            raise OptimizationUnitNotFoundError(f"Optimization Unit with ID {unit_id} not found")
+
+        updated_unit = config_service.assign_miners_to_optimization_unit(unit_id, miner_ids)
+
+        response = EnergyOptimizationUnitSchema.from_model(updated_unit)
+
+        return response
+    except OptimizationUnitNotFoundError as e:
+        raise HTTPException(status_code=404, detail="Optimization Unit not found") from e
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.post("/optimization-units/{unit_id}/miners/single", response_model=EnergyOptimizationUnitSchema)
+async def add_target_miner(
+    unit_id: EntityId,
+    miner_id: EntityId,
+    config_service: Annotated[ConfigurationServiceInterface, Depends(get_config_service)],
+) -> EnergyOptimizationUnitSchema:
+    """Add a single target miner to an optimization unit."""
+    try:
+        optimization_unit = config_service.get_optimization_unit(unit_id)
+
+        if optimization_unit is None:
+            raise OptimizationUnitNotFoundError(f"Optimization Unit with ID {unit_id} not found")
+
+        updated_unit = config_service.add_miner_to_optimization_unit(unit_id, miner_id)
+
+        response = EnergyOptimizationUnitSchema.from_model(updated_unit)
+
+        return response
+    except OptimizationUnitNotFoundError as e:
+        raise HTTPException(status_code=404, detail="Optimization Unit not found") from e
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.delete("/optimization-units/{unit_id}/miners/{miner_id}", response_model=EnergyOptimizationUnitSchema)
+async def remove_target_miner(
+    unit_id: EntityId,
+    miner_id: EntityId,
+    config_service: Annotated[ConfigurationServiceInterface, Depends(get_config_service)],
+) -> EnergyOptimizationUnitSchema:
+    """Remove a target miner from an optimization unit."""
+    try:
+        optimization_unit = config_service.get_optimization_unit(unit_id)
+
+        if optimization_unit is None:
+            raise OptimizationUnitNotFoundError(f"Optimization Unit with ID {unit_id} not found")
+
+        updated_unit = config_service.remove_miner_from_optimization_unit(unit_id, miner_id)
+
+        response = EnergyOptimizationUnitSchema.from_model(updated_unit)
+
+        return response
+    except OptimizationUnitNotFoundError as e:
+        raise HTTPException(status_code=404, detail="Optimization Unit not found") from e
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.post("/optimization-units/{unit_id}/notifiers", response_model=EnergyOptimizationUnitSchema)
+async def assign_notifiers(
+    unit_id: EntityId,
+    notifier_ids: List[EntityId],
+    config_service: Annotated[ConfigurationServiceInterface, Depends(get_config_service)],
+) -> EnergyOptimizationUnitSchema:
+    """Assign notifiers to an optimization unit."""
+    try:
+        optimization_unit = config_service.get_optimization_unit(unit_id)
+
+        if optimization_unit is None:
+            raise OptimizationUnitNotFoundError(f"Optimization Unit with ID {unit_id} not found")
+
+        updated_unit = config_service.assign_notifiers_to_optimization_unit(unit_id, notifier_ids)
+
+        response = EnergyOptimizationUnitSchema.from_model(updated_unit)
+
+        return response
+    except OptimizationUnitNotFoundError as e:
+        raise HTTPException(status_code=404, detail="Optimization Unit not found") from e
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.post("/optimization-units/{unit_id}/notifiers/single", response_model=EnergyOptimizationUnitSchema)
+async def add_notifier(
+    unit_id: EntityId,
+    notifier_id: EntityId,
+    config_service: Annotated[ConfigurationServiceInterface, Depends(get_config_service)],
+) -> EnergyOptimizationUnitSchema:
+    """Add a single notifier to an optimization unit."""
+    try:
+        optimization_unit = config_service.get_optimization_unit(unit_id)
+
+        if optimization_unit is None:
+            raise OptimizationUnitNotFoundError(f"Optimization Unit with ID {unit_id} not found")
+
+        updated_unit = config_service.add_notifier_to_optimization_unit(unit_id, notifier_id)
+
+        response = EnergyOptimizationUnitSchema.from_model(updated_unit)
+
+        return response
+    except OptimizationUnitNotFoundError as e:
+        raise HTTPException(status_code=404, detail="Optimization Unit not found") from e
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.delete("/optimization-units/{unit_id}/notifiers/{notifier_id}", response_model=EnergyOptimizationUnitSchema)
+async def remove_notifier(
+    unit_id: EntityId,
+    notifier_id: EntityId,
+    config_service: Annotated[ConfigurationServiceInterface, Depends(get_config_service)],
+) -> EnergyOptimizationUnitSchema:
+    """Remove a notifier from an optimization unit."""
+    try:
+        optimization_unit = config_service.get_optimization_unit(unit_id)
+
+        if optimization_unit is None:
+            raise OptimizationUnitNotFoundError(f"Optimization Unit with ID {unit_id} not found")
+
+        updated_unit = config_service.remove_notifier_from_optimization_unit(unit_id, notifier_id)
+
+        response = EnergyOptimizationUnitSchema.from_model(updated_unit)
+
+        return response
+    except OptimizationUnitNotFoundError as e:
+        raise HTTPException(status_code=404, detail="Optimization Unit not found") from e
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e

--- a/edge_mining/adapters/domain/optimization_unit/schemas.py
+++ b/edge_mining/adapters/domain/optimization_unit/schemas.py
@@ -1,0 +1,444 @@
+"""Validation schemas for optimization unit domain."""
+
+import uuid
+from typing import List, Optional
+
+from pydantic import BaseModel, Field, field_serializer, field_validator
+
+from edge_mining.domain.common import EntityId
+from edge_mining.domain.optimization_unit.aggregate_roots import EnergyOptimizationUnit
+
+
+class EnergyOptimizationUnitSchema(BaseModel):
+    """Schema for EnergyOptimizationUnit aggregate root with complete validation."""
+
+    id: str = Field(..., description="Unique identifier for the energy optimization unit")
+    name: str = Field(default="", description="Energy optimization unit name")
+    description: Optional[str] = Field(default=None, description="Energy optimization unit description")
+    is_enabled: bool = Field(default=False, description="Whether the optimization unit is enabled")
+    policy_id: Optional[str] = Field(default=None, description="ID of the policy to be used for optimization")
+    target_miner_ids: List[str] = Field(default_factory=list, description="List of target miner IDs to be controlled")
+    energy_source_id: Optional[str] = Field(default=None, description="ID of the energy source to be used")
+    home_forecast_provider_id: Optional[str] = Field(
+        default=None, description="ID of the home load forecast provider to be used"
+    )
+    performance_tracker_id: Optional[str] = Field(default=None, description="ID of the performance tracker to be used")
+    notifier_ids: List[str] = Field(default_factory=list, description="List of notifier IDs to be used")
+
+    @field_validator("id")
+    @classmethod
+    def validate_id(cls, v: str) -> str:
+        """Validate that id is a valid UUID string."""
+        try:
+            uuid.UUID(v)
+        except ValueError as exc:
+            raise ValueError("id must be a valid UUID string") from exc
+        return v
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        """Validate optimization unit name."""
+        v = v.strip()
+        if not v:
+            v = ""
+        return v
+
+    @field_validator("description")
+    @classmethod
+    def validate_description(cls, v: Optional[str]) -> Optional[str]:
+        """Validate optimization unit description."""
+        if v is not None:
+            v = v.strip()
+            if not v:
+                v = None
+        return v
+
+    @field_validator("policy_id")
+    @classmethod
+    def validate_policy_id(cls, v: Optional[str]) -> Optional[str]:
+        """Validate that policy_id is a valid UUID string if provided."""
+        if v is not None:
+            try:
+                uuid.UUID(v)
+            except ValueError as exc:
+                raise ValueError("policy_id must be a valid UUID string") from exc
+        return v
+
+    @field_validator("target_miner_ids")
+    @classmethod
+    def validate_target_miner_ids(cls, v: List[str]) -> List[str]:
+        """Validate that all target_miner_ids are valid UUID strings."""
+        for miner_id in v:
+            try:
+                uuid.UUID(miner_id)
+            except ValueError as exc:
+                raise ValueError(f"target_miner_id '{miner_id}' must be a valid UUID string") from exc
+        return v
+
+    @field_validator("energy_source_id")
+    @classmethod
+    def validate_energy_source_id(cls, v: Optional[str]) -> Optional[str]:
+        """Validate that energy_source_id is a valid UUID string if provided."""
+        if v is not None:
+            try:
+                uuid.UUID(v)
+            except ValueError as exc:
+                raise ValueError("energy_source_id must be a valid UUID string") from exc
+        return v
+
+    @field_validator("home_forecast_provider_id")
+    @classmethod
+    def validate_home_forecast_provider_id(cls, v: Optional[str]) -> Optional[str]:
+        """Validate that home_forecast_provider_id is a valid UUID string if provided."""
+        if v is not None:
+            try:
+                uuid.UUID(v)
+            except ValueError as exc:
+                raise ValueError("home_forecast_provider_id must be a valid UUID string") from exc
+        return v
+
+    @field_validator("performance_tracker_id")
+    @classmethod
+    def validate_performance_tracker_id(cls, v: Optional[str]) -> Optional[str]:
+        """Validate that performance_tracker_id is a valid UUID string if provided."""
+        if v is not None:
+            try:
+                uuid.UUID(v)
+            except ValueError as exc:
+                raise ValueError("performance_tracker_id must be a valid UUID string") from exc
+        return v
+
+    @field_validator("notifier_ids")
+    @classmethod
+    def validate_notifier_ids(cls, v: List[str]) -> List[str]:
+        """Validate that all notifier_ids are valid UUID strings."""
+        for notifier_id in v:
+            try:
+                uuid.UUID(notifier_id)
+            except ValueError as exc:
+                raise ValueError(f"notifier_id '{notifier_id}' must be a valid UUID string") from exc
+        return v
+
+    @classmethod
+    def from_model(cls, optimization_unit: EnergyOptimizationUnit) -> "EnergyOptimizationUnitSchema":
+        """Create EnergyOptimizationUnitSchema from an EnergyOptimizationUnit domain model instance."""
+        return cls(
+            id=str(optimization_unit.id),
+            name=optimization_unit.name,
+            description=optimization_unit.description,
+            is_enabled=optimization_unit.is_enabled,
+            policy_id=str(optimization_unit.policy_id) if optimization_unit.policy_id else None,
+            target_miner_ids=[str(miner_id) for miner_id in optimization_unit.target_miner_ids],
+            energy_source_id=str(optimization_unit.energy_source_id) if optimization_unit.energy_source_id else None,
+            home_forecast_provider_id=(
+                str(optimization_unit.home_forecast_provider_id)
+                if optimization_unit.home_forecast_provider_id
+                else None
+            ),
+            performance_tracker_id=(
+                str(optimization_unit.performance_tracker_id) if optimization_unit.performance_tracker_id else None
+            ),
+            notifier_ids=[str(notifier_id) for notifier_id in optimization_unit.notifier_ids],
+        )
+
+    @field_serializer("id")
+    def serialize_id(self, value: str) -> str:
+        """Serialize id field."""
+        return str(value)
+
+    @field_serializer("policy_id")
+    def serialize_policy_id(self, value: Optional[str]) -> Optional[str]:
+        """Serialize policy_id field."""
+        return str(value) if value is not None else None
+
+    @field_serializer("target_miner_ids")
+    def serialize_target_miner_ids(self, value: List[str]) -> List[str]:
+        """Serialize target_miner_ids field."""
+        return [str(miner_id) for miner_id in value]
+
+    @field_serializer("energy_source_id")
+    def serialize_energy_source_id(self, value: Optional[str]) -> Optional[str]:
+        """Serialize energy_source_id field."""
+        return str(value) if value is not None else None
+
+    @field_serializer("home_forecast_provider_id")
+    def serialize_home_forecast_provider_id(self, value: Optional[str]) -> Optional[str]:
+        """Serialize home_forecast_provider_id field."""
+        return str(value) if value is not None else None
+
+    @field_serializer("performance_tracker_id")
+    def serialize_performance_tracker_id(self, value: Optional[str]) -> Optional[str]:
+        """Serialize performance_tracker_id field."""
+        return str(value) if value is not None else None
+
+    @field_serializer("notifier_ids")
+    def serialize_notifier_ids(self, value: List[str]) -> List[str]:
+        """Serialize notifier_ids field."""
+        return [str(notifier_id) for notifier_id in value]
+
+    def to_model(self) -> EnergyOptimizationUnit:
+        """Convert EnergyOptimizationUnitSchema back to EnergyOptimizationUnit domain model instance."""
+        return EnergyOptimizationUnit(
+            id=EntityId(uuid.UUID(self.id)),
+            name=self.name,
+            description=self.description,
+            is_enabled=self.is_enabled,
+            policy_id=EntityId(uuid.UUID(self.policy_id)) if self.policy_id else None,
+            target_miner_ids=[EntityId(uuid.UUID(miner_id)) for miner_id in self.target_miner_ids],
+            energy_source_id=EntityId(uuid.UUID(self.energy_source_id)) if self.energy_source_id else None,
+            home_forecast_provider_id=(
+                EntityId(uuid.UUID(self.home_forecast_provider_id)) if self.home_forecast_provider_id else None
+            ),
+            performance_tracker_id=(
+                EntityId(uuid.UUID(self.performance_tracker_id)) if self.performance_tracker_id else None
+            ),
+            notifier_ids=[EntityId(uuid.UUID(notifier_id)) for notifier_id in self.notifier_ids],
+        )
+
+    class Config:
+        """Pydantic configuration."""
+
+        use_enum_values = True
+        validate_assignment = True
+        arbitrary_types_allowed = True
+        json_encoders = {
+            uuid.UUID: str,
+        }
+
+
+class EnergyOptimizationUnitCreateSchema(BaseModel):
+    """Schema for creating a new energy optimization unit."""
+
+    name: str = Field(default="", description="Energy optimization unit name")
+    description: Optional[str] = Field(default=None, description="Energy optimization unit description")
+    policy_id: Optional[str] = Field(default=None, description="ID of the policy to be used for optimization")
+    target_miner_ids: List[str] = Field(default_factory=list, description="List of target miner IDs to be controlled")
+    energy_source_id: Optional[str] = Field(default=None, description="ID of the energy source to be used")
+    home_forecast_provider_id: Optional[str] = Field(
+        default=None, description="ID of the home load forecast provider to be used"
+    )
+    performance_tracker_id: Optional[str] = Field(default=None, description="ID of the performance tracker to be used")
+    notifier_ids: List[str] = Field(default_factory=list, description="List of notifier IDs to be used")
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        """Validate optimization unit name."""
+        v = v.strip()
+        if not v:
+            v = ""
+        return v
+
+    @field_validator("description")
+    @classmethod
+    def validate_description(cls, v: Optional[str]) -> Optional[str]:
+        """Validate optimization unit description."""
+        if v is not None:
+            v = v.strip()
+            if not v:
+                v = None
+        return v
+
+    @field_validator("policy_id")
+    @classmethod
+    def validate_policy_id(cls, v: Optional[str]) -> Optional[str]:
+        """Validate that policy_id is a valid UUID string if provided."""
+        if v is not None:
+            try:
+                uuid.UUID(v)
+            except ValueError as exc:
+                raise ValueError("policy_id must be a valid UUID string") from exc
+        return v
+
+    @field_validator("target_miner_ids")
+    @classmethod
+    def validate_target_miner_ids(cls, v: List[str]) -> List[str]:
+        """Validate that all target_miner_ids are valid UUID strings."""
+        for miner_id in v:
+            try:
+                uuid.UUID(miner_id)
+            except ValueError as exc:
+                raise ValueError(f"target_miner_id '{miner_id}' must be a valid UUID string") from exc
+        return v
+
+    @field_validator("energy_source_id")
+    @classmethod
+    def validate_energy_source_id(cls, v: Optional[str]) -> Optional[str]:
+        """Validate that energy_source_id is a valid UUID string if provided."""
+        if v is not None:
+            try:
+                uuid.UUID(v)
+            except ValueError as exc:
+                raise ValueError("energy_source_id must be a valid UUID string") from exc
+        return v
+
+    @field_validator("home_forecast_provider_id")
+    @classmethod
+    def validate_home_forecast_provider_id(cls, v: Optional[str]) -> Optional[str]:
+        """Validate that home_forecast_provider_id is a valid UUID string if provided."""
+        if v is not None:
+            try:
+                uuid.UUID(v)
+            except ValueError as exc:
+                raise ValueError("home_forecast_provider_id must be a valid UUID string") from exc
+        return v
+
+    @field_validator("performance_tracker_id")
+    @classmethod
+    def validate_performance_tracker_id(cls, v: Optional[str]) -> Optional[str]:
+        """Validate that performance_tracker_id is a valid UUID string if provided."""
+        if v is not None:
+            try:
+                uuid.UUID(v)
+            except ValueError as exc:
+                raise ValueError("performance_tracker_id must be a valid UUID string") from exc
+        return v
+
+    @field_validator("notifier_ids")
+    @classmethod
+    def validate_notifier_ids(cls, v: List[str]) -> List[str]:
+        """Validate that all notifier_ids are valid UUID strings."""
+        for notifier_id in v:
+            try:
+                uuid.UUID(notifier_id)
+            except ValueError as exc:
+                raise ValueError(f"notifier_id '{notifier_id}' must be a valid UUID string") from exc
+        return v
+
+    def to_model(self) -> EnergyOptimizationUnit:
+        """Convert EnergyOptimizationUnitCreateSchema to an EnergyOptimizationUnit domain model instance."""
+        return EnergyOptimizationUnit(
+            id=EntityId(uuid.uuid4()),
+            name=self.name,
+            description=self.description,
+            is_enabled=False,
+            policy_id=EntityId(uuid.UUID(self.policy_id)) if self.policy_id else None,
+            target_miner_ids=[EntityId(uuid.UUID(miner_id)) for miner_id in self.target_miner_ids],
+            energy_source_id=EntityId(uuid.UUID(self.energy_source_id)) if self.energy_source_id else None,
+            home_forecast_provider_id=(
+                EntityId(uuid.UUID(self.home_forecast_provider_id)) if self.home_forecast_provider_id else None
+            ),
+            performance_tracker_id=(
+                EntityId(uuid.UUID(self.performance_tracker_id)) if self.performance_tracker_id else None
+            ),
+            notifier_ids=[EntityId(uuid.UUID(notifier_id)) for notifier_id in self.notifier_ids],
+        )
+
+    class Config:
+        """Pydantic configuration."""
+
+        use_enum_values = True
+        validate_assignment = True
+        json_encoders = {
+            uuid.UUID: str,
+        }
+
+
+class EnergyOptimizationUnitUpdateSchema(BaseModel):
+    """Schema for updating an existing energy optimization unit."""
+
+    name: str = Field(default="", description="Energy optimization unit name")
+    description: Optional[str] = Field(default=None, description="Energy optimization unit description")
+    policy_id: Optional[str] = Field(default=None, description="ID of the policy to be used for optimization")
+    target_miner_ids: List[str] = Field(default_factory=list, description="List of target miner IDs to be controlled")
+    energy_source_id: Optional[str] = Field(default=None, description="ID of the energy source to be used")
+    home_forecast_provider_id: Optional[str] = Field(
+        default=None, description="ID of the home load forecast provider to be used"
+    )
+    performance_tracker_id: Optional[str] = Field(default=None, description="ID of the performance tracker to be used")
+    notifier_ids: List[str] = Field(default_factory=list, description="List of notifier IDs to be used")
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        """Validate optimization unit name."""
+        v = v.strip()
+        if not v:
+            v = ""
+        return v
+
+    @field_validator("description")
+    @classmethod
+    def validate_description(cls, v: Optional[str]) -> Optional[str]:
+        """Validate optimization unit description."""
+        if v is not None:
+            v = v.strip()
+            if not v:
+                v = None
+        return v
+
+    @field_validator("policy_id")
+    @classmethod
+    def validate_policy_id(cls, v: Optional[str]) -> Optional[str]:
+        """Validate that policy_id is a valid UUID string if provided."""
+        if v is not None:
+            try:
+                uuid.UUID(v)
+            except ValueError as exc:
+                raise ValueError("policy_id must be a valid UUID string") from exc
+        return v
+
+    @field_validator("target_miner_ids")
+    @classmethod
+    def validate_target_miner_ids(cls, v: List[str]) -> List[str]:
+        """Validate that all target_miner_ids are valid UUID strings."""
+        for miner_id in v:
+            try:
+                uuid.UUID(miner_id)
+            except ValueError as exc:
+                raise ValueError(f"target_miner_id '{miner_id}' must be a valid UUID string") from exc
+        return v
+
+    @field_validator("energy_source_id")
+    @classmethod
+    def validate_energy_source_id(cls, v: Optional[str]) -> Optional[str]:
+        """Validate that energy_source_id is a valid UUID string if provided."""
+        if v is not None:
+            try:
+                uuid.UUID(v)
+            except ValueError as exc:
+                raise ValueError("energy_source_id must be a valid UUID string") from exc
+        return v
+
+    @field_validator("home_forecast_provider_id")
+    @classmethod
+    def validate_home_forecast_provider_id(cls, v: Optional[str]) -> Optional[str]:
+        """Validate that home_forecast_provider_id is a valid UUID string if provided."""
+        if v is not None:
+            try:
+                uuid.UUID(v)
+            except ValueError as exc:
+                raise ValueError("home_forecast_provider_id must be a valid UUID string") from exc
+        return v
+
+    @field_validator("performance_tracker_id")
+    @classmethod
+    def validate_performance_tracker_id(cls, v: Optional[str]) -> Optional[str]:
+        """Validate that performance_tracker_id is a valid UUID string if provided."""
+        if v is not None:
+            try:
+                uuid.UUID(v)
+            except ValueError as exc:
+                raise ValueError("performance_tracker_id must be a valid UUID string") from exc
+        return v
+
+    @field_validator("notifier_ids")
+    @classmethod
+    def validate_notifier_ids(cls, v: List[str]) -> List[str]:
+        """Validate that all notifier_ids are valid UUID strings."""
+        for notifier_id in v:
+            try:
+                uuid.UUID(notifier_id)
+            except ValueError as exc:
+                raise ValueError(f"notifier_id '{notifier_id}' must be a valid UUID string") from exc
+        return v
+
+    class Config:
+        """Pydantic configuration."""
+
+        use_enum_values = True
+        validate_assignment = True
+        json_encoders = {
+            uuid.UUID: str,
+        }

--- a/edge_mining/adapters/domain/policy/cli/commands.py
+++ b/edge_mining/adapters/domain/policy/cli/commands.py
@@ -261,7 +261,7 @@ def select_optimization_policy(
     return selected_policy
 
 
-def print_optimization_policy_details(policy: OptimizationPolicy) -> None:
+def print_optimization_policy_details(policy: OptimizationPolicy, show_rule_details: bool = True) -> None:
     """Print the details of an optimization policy."""
     click.echo("")
     click.echo("| ID: " + click.style(str(policy.id), fg="yellow"))
@@ -269,21 +269,22 @@ def print_optimization_policy_details(policy: OptimizationPolicy) -> None:
     if policy.description:
         click.echo("| Description: " + click.style(policy.description, fg="cyan"))
 
-    click.echo(f"| Start Rules: {click.style(str(len(policy.start_rules)), fg='green')}")
-    if policy.start_rules:
-        for rule in policy.start_rules:
-            print_rule_details(rule)
-    else:
-        click.echo("|- No start rules defined")
+    if show_rule_details:
+        click.echo(f"| Start Rules: {click.style(str(len(policy.start_rules)), fg='green')}")
+        if policy.start_rules:
+            for rule in policy.start_rules:
+                print_rule_details(rule)
+        else:
+            click.echo("|- No start rules defined")
 
-    click.echo("|------------------------------------------------------------------------")
+        click.echo("|------------------------------------------------------------------------")
 
-    click.echo(f"| Stop Rules: {click.style(str(len(policy.stop_rules)), fg='red')}")
-    if policy.stop_rules:
-        for rule in policy.stop_rules:
-            print_rule_details(rule)
-    else:
-        click.echo("|- No stop rules defined")
+        click.echo(f"| Stop Rules: {click.style(str(len(policy.stop_rules)), fg='red')}")
+        if policy.stop_rules:
+            for rule in policy.stop_rules:
+                print_rule_details(rule)
+        else:
+            click.echo("|- No stop rules defined")
 
 
 def print_rule_details(rule: AutomationRule) -> None:

--- a/edge_mining/adapters/infrastructure/api/main_api.py
+++ b/edge_mining/adapters/infrastructure/api/main_api.py
@@ -10,6 +10,7 @@ from edge_mining.adapters.domain.energy.fast_api.router import router as energy_
 from edge_mining.adapters.domain.forecast.fast_api.router import router as forecast_router
 from edge_mining.adapters.domain.miner.fast_api.router import router as miner_router
 from edge_mining.adapters.domain.notification.fast_api.router import router as notification_router
+from edge_mining.adapters.domain.optimization_unit.fast_api.router import router as optimization_unit_router
 from edge_mining.adapters.domain.policy.fast_api.router import router as policy_router
 
 # Import dependency injection setup functions
@@ -72,6 +73,7 @@ app.add_middleware(
 app.include_router(energy_router, prefix="/api/v1", tags=["energy"])
 app.include_router(miner_router, prefix="/api/v1", tags=["mining"])
 app.include_router(policy_router, prefix="/api/v1", tags=["policy"])
+app.include_router(optimization_unit_router, prefix="/api/v1", tags=["optimization_unit"])
 app.include_router(external_services_router, prefix="/api/v1", tags=["external_services"])
 app.include_router(rule_engine_router, prefix="/api/v1", tags=["rule_engine"])
 app.include_router(notification_router, prefix="/api/v1", tags=["notification"])

--- a/edge_mining/application/interfaces.py
+++ b/edge_mining/application/interfaces.py
@@ -426,6 +426,12 @@ class ConfigurationServiceInterface(ABC):
         """Deactivate an optimization unit in the system."""
 
     @abstractmethod
+    def assign_miners_to_optimization_unit(
+        self, unit_id: EntityId, miner_ids: List[EntityId]
+    ) -> EnergyOptimizationUnit:
+        """Assign target miners to an optimization unit."""
+
+    @abstractmethod
     def add_miner_to_optimization_unit(self, unit_id: EntityId, miner_id: EntityId) -> EnergyOptimizationUnit:
         """Add a miner to an optimization unit."""
 
@@ -454,6 +460,12 @@ class ConfigurationServiceInterface(ABC):
         self, unit_id: EntityId, performance_tracker_id: EntityId
     ) -> EnergyOptimizationUnit:
         """Assign a performance tracker to an optimization unit."""
+
+    @abstractmethod
+    def assign_notifiers_to_optimization_unit(
+        self, unit_id: EntityId, notifier_ids: List[EntityId]
+    ) -> EnergyOptimizationUnit:
+        """Assign notifiers to an optimization unit."""
 
     @abstractmethod
     def add_notifier_to_optimization_unit(self, unit_id: EntityId, notifier_id: EntityId) -> EnergyOptimizationUnit:

--- a/edge_mining/application/interfaces.py
+++ b/edge_mining/application/interfaces.py
@@ -478,7 +478,7 @@ class ConfigurationServiceInterface(ABC):
         """Remove a notifier from an optimization unit."""
 
     @abstractmethod
-    def check_optimization_unit(self, optimization_unit: EnergyOptimizationUnit) -> bool:
+    def check_optimization_unit(self, optimization_unit: EnergyOptimizationUnit, strict: bool = False) -> bool:
         """Check if an optimization unit is valid and can be used."""
 
     # --- External Service Management ---

--- a/edge_mining/application/services/adapter_service.py
+++ b/edge_mining/application/services/adapter_service.py
@@ -164,6 +164,7 @@ class AdapterService(AdapterServiceInterface):
             return cached_instance
 
         # Retrieve the external service associated to the energy monitor
+        external_service: Optional[ExternalServicePort] = None
         if energy_monitor.external_service_id:
             external_service = self.get_external_service(energy_monitor.external_service_id)
             if not external_service:

--- a/edge_mining/application/services/configuration_service.py
+++ b/edge_mining/application/services/configuration_service.py
@@ -904,6 +904,25 @@ class ConfigurationService(ConfigurationServiceInterface):
 
         return optimization_unit
 
+    def assign_miners_to_optimization_unit(
+        self, unit_id: EntityId, miner_ids: List[EntityId]
+    ) -> EnergyOptimizationUnit:
+        """Assign target miners to an optimization unit."""
+        self.logger.info(f"Assigning miners {miner_ids} to optimization unit {unit_id}")
+
+        optimization_unit = self.optimization_unit_repo.get_by_id(unit_id)
+
+        if not optimization_unit:
+            raise OptimizationUnitNotFoundError(f"Optimization Unit with ID {unit_id} not found.")
+
+        optimization_unit.target_miner_ids = miner_ids
+
+        self.check_optimization_unit(optimization_unit)
+
+        self.optimization_unit_repo.update(optimization_unit)
+
+        return optimization_unit
+
     def add_miner_to_optimization_unit(self, unit_id: EntityId, miner_id: EntityId) -> EnergyOptimizationUnit:
         """Add a miner to an optimization unit."""
         self.logger.info(f"Adding miner {miner_id} to optimization unit {unit_id}")
@@ -1005,6 +1024,25 @@ class ConfigurationService(ConfigurationServiceInterface):
 
         optimization_unit.performance_tracker_id = performance_tracker_id
         self.check_optimization_unit(optimization_unit)
+        self.optimization_unit_repo.update(optimization_unit)
+
+        return optimization_unit
+
+    def assign_notifiers_to_optimization_unit(
+        self, unit_id: EntityId, notifier_ids: List[EntityId]
+    ) -> EnergyOptimizationUnit:
+        """Assign notifiers to an optimization unit."""
+        self.logger.info(f"Assigning notifiers {notifier_ids} to optimization unit {unit_id}")
+
+        optimization_unit = self.optimization_unit_repo.get_by_id(unit_id)
+
+        if not optimization_unit:
+            raise OptimizationUnitNotFoundError(f"Optimization Unit with ID {unit_id} not found.")
+
+        optimization_unit.notifier_ids = notifier_ids
+
+        self.check_optimization_unit(optimization_unit)
+
         self.optimization_unit_repo.update(optimization_unit)
 
         return optimization_unit

--- a/edge_mining/application/services/configuration_service.py
+++ b/edge_mining/application/services/configuration_service.py
@@ -860,7 +860,12 @@ class ConfigurationService(ConfigurationServiceInterface):
         if notifier_ids is not None:
             optimization_unit.notifier_ids = notifier_ids
 
-        self.check_optimization_unit(optimization_unit)
+        # On update, perform a strict checks if the optimization unit is enabled
+        try:
+            self.check_optimization_unit(optimization_unit=optimization_unit, strict=optimization_unit.is_enabled)
+        except Exception as e:
+            self.logger.error(f"Optimization unit configuration error: {e}")
+            optimization_unit.disable()
 
         self.optimization_unit_repo.update(optimization_unit)
 
@@ -875,7 +880,7 @@ class ConfigurationService(ConfigurationServiceInterface):
         if not optimization_unit:
             raise OptimizationUnitNotFoundError(f"Optimization Unit with ID {unit_id} not found.")
 
-        self.check_optimization_unit(optimization_unit)
+        self.check_optimization_unit(optimization_unit=optimization_unit, strict=True)
 
         if optimization_unit.policy_id is None:
             raise OptimizationUnitConfigurationError(
@@ -1087,7 +1092,7 @@ class ConfigurationService(ConfigurationServiceInterface):
 
         return optimization_unit
 
-    def check_optimization_unit(self, optimization_unit: EnergyOptimizationUnit) -> bool:
+    def check_optimization_unit(self, optimization_unit: EnergyOptimizationUnit, strict: bool = False) -> bool:
         """Check if an optimization unit is valid and can be used."""
         self.logger.debug(f"Checking optimization unit {optimization_unit.id} ({optimization_unit.name})")
 
@@ -1099,6 +1104,11 @@ class ConfigurationService(ConfigurationServiceInterface):
             policy = self.policy_repo.get_by_id(optimization_unit.policy_id)
             if not policy:
                 raise PolicyNotFoundError(f"Optimization Policy with ID {optimization_unit.policy_id} not found.")
+        else:
+            if strict:
+                raise OptimizationUnitConfigurationError(
+                    f"Optimization Unit {optimization_unit.id} must have a policy assigned."
+                )
 
         # Check if the miners are valid
         if optimization_unit.target_miner_ids:
@@ -1106,6 +1116,11 @@ class ConfigurationService(ConfigurationServiceInterface):
                 miner = self.miner_repo.get_by_id(miner_id)
                 if not miner:
                     raise MinerNotFoundError(f"Miner with ID {miner_id} not found.")
+        else:
+            if strict:
+                raise OptimizationUnitConfigurationError(
+                    f"Optimization Unit {optimization_unit.id} must have at least one target miner assigned."
+                )
 
         # Check if the energy source is valid
         if optimization_unit.energy_source_id:
@@ -1113,6 +1128,11 @@ class ConfigurationService(ConfigurationServiceInterface):
             if not energy_source:
                 raise EnergySourceNotFoundError(
                     f"Energy Source with ID {optimization_unit.energy_source_id} not found."
+                )
+        else:
+            if strict:
+                raise OptimizationUnitConfigurationError(
+                    f"Optimization Unit {optimization_unit.id} must have an energy source assigned."
                 )
 
         # Check if the home forecast provider is valid

--- a/edge_mining/application/services/optimization_service.py
+++ b/edge_mining/application/services/optimization_service.py
@@ -38,6 +38,7 @@ from edge_mining.domain.policy.common import MiningDecision
 from edge_mining.domain.policy.entities import AutomationRule
 from edge_mining.domain.policy.exceptions import PolicyError, RuleEngineError, RuleEvaluationError, RuleLoadError
 from edge_mining.domain.policy.ports import OptimizationPolicyRepository
+from edge_mining.domain.policy.services import RuleEngine
 from edge_mining.domain.policy.value_objects import DecisionalContext, Sun
 from edge_mining.shared.logging.port import LoggerPort
 
@@ -334,7 +335,11 @@ class OptimizationService(OptimizationServiceInterface):
 
         # --- Notifiers ---
         unit_notifiers: List[NotificationPort] = []
-        unit_notifiers = self.adapter_service.get_notifiers(optimization_unit.notifier_ids)
+        try:
+            unit_notifiers = self.adapter_service.get_notifiers(optimization_unit.notifier_ids)
+        except Exception as e:
+            if self.logger:
+                self.logger.error(f"Error getting notifiers for optimization unit '{optimization_unit.name}': {e}")
 
         # --- Policy ---
         if not optimization_unit.policy_id:
@@ -380,7 +385,11 @@ class OptimizationService(OptimizationServiceInterface):
         # --- Energy Monitor ---
         energy_monitor: Optional[EnergyMonitorPort] = None
         if energy_source.energy_monitor_id:
-            energy_monitor = self.adapter_service.get_energy_monitor(energy_source)
+            try:
+                energy_monitor = self.adapter_service.get_energy_monitor(energy_source)
+            except Exception as e:
+                if self.logger:
+                    self.logger.critical(f"Error getting energy monitor for energy source '{energy_source.name}': {e}")
         if not energy_monitor:
             if self.logger:
                 self.logger.error(
@@ -398,7 +407,11 @@ class OptimizationService(OptimizationServiceInterface):
         # --- Forecast Provider ---
         forecast_provider: Optional[ForecastProviderPort] = None
         if energy_source.forecast_provider_id:
-            forecast_provider = self.adapter_service.get_forecast_provider(energy_source)
+            try:
+                forecast_provider = self.adapter_service.get_forecast_provider(energy_source)
+            except Exception as e:
+                if self.logger:
+                    self.logger.error(f"Error getting forecast provider for energy source '{energy_source.name}': {e}")
         # Forecast is optional, so log a warning if it's missing but continue
         if not forecast_provider:
             if self.logger:
@@ -411,9 +424,15 @@ class OptimizationService(OptimizationServiceInterface):
         # --- Home Forecast Provider ---
         home_forecast_provider: Optional[HomeForecastProviderPort] = None
         if optimization_unit.home_forecast_provider_id:
-            home_forecast_provider = self.adapter_service.get_home_load_forecast_provider(
-                optimization_unit.home_forecast_provider_id
-            )
+            try:
+                home_forecast_provider = self.adapter_service.get_home_load_forecast_provider(
+                    optimization_unit.home_forecast_provider_id
+                )
+            except Exception as e:
+                if self.logger:
+                    self.logger.error(
+                        f"Error getting home forecast provider for optimization unit '{optimization_unit.name}': {e}"
+                    )
         # Home forecast provider is optional, so log a warning if it's missing but
         # continue
         if not home_forecast_provider:
@@ -428,9 +447,15 @@ class OptimizationService(OptimizationServiceInterface):
         # --- Mining Performance Tracker ---
         mining_performance_tracker: Optional[MiningPerformanceTrackerPort] = None
         if optimization_unit.performance_tracker_id:
-            mining_performance_tracker = self.adapter_service.get_mining_performance_tracker(
-                optimization_unit.performance_tracker_id
-            )
+            try:
+                mining_performance_tracker = self.adapter_service.get_mining_performance_tracker(
+                    optimization_unit.performance_tracker_id
+                )
+            except Exception as e:
+                if self.logger:
+                    self.logger.error(
+                        f"Error getting mining performance tracker for optimization unit '{optimization_unit.name}': {e}"
+                    )
         # Mining performance tracker is optional, so log a warning if it's missing
         # but continue
         if not mining_performance_tracker:
@@ -595,7 +620,11 @@ class OptimizationService(OptimizationServiceInterface):
         # --- Miner Controller ---
         miner_controller: Optional[MinerControlPort] = None
         if miner.controller_id:
-            miner_controller = self.adapter_service.get_miner_controller(miner)
+            try:
+                miner_controller = self.adapter_service.get_miner_controller(miner)
+            except Exception as e:
+                if self.logger:
+                    self.logger.critical(f"Error getting controller for miner {miner_id}: {e}")
             if not miner_controller:
                 if self.logger:
                     self.logger.error(
@@ -656,7 +685,12 @@ class OptimizationService(OptimizationServiceInterface):
             )
 
             # Create the rule engine instance
-            rule_engine = self.adapter_service.get_rule_engine()
+            rule_engine: Optional[RuleEngine] = None
+            try:
+                rule_engine = self.adapter_service.get_rule_engine()
+            except Exception as e:
+                if self.logger:
+                    self.logger.critical(f"Error getting rule engine: {e}")
             if not rule_engine:
                 if self.logger:
                     self.logger.error(


### PR DESCRIPTION
This branch implements the work needed for issue #32, delivering both the command-line interface and the REST API required to create, inspect, update, enable/disable, and delete Energy Optimization Units. It also introduces the associated validation schemas and integrates the new router into the FastAPI bootstrap so the endpoints are exposed alongside the existing domain APIs.

## CLI Interaction
- Entry point: `optimization_unit_menu(configuration_service, logger)` adds three options to the interactive console: create, list, and manage units.
- Creation flow (`handle_add_optimization_unit`) walks the operator through selecting energy sources, policies, miners (multi-select), and notifiers. It refuses to proceed if any required selection is missing and logs errors via the provided logger.
- Management flow (`manage_single_optimization_unit_menu`) lets operators activate/deactivate, update metadata and relationships, and add/remove individual miners or notifiers, delegating to helper functions such as `manage_assign_energy_source` and `manage_add_target_miner`.
- Listing helpers (`list_optimization_units`, `print_optimization_unit_details`) format the output with colorized `click` styles for immediate readability.

## REST API Interaction
All routes are mounted under `/api/v1/optimization-units` thanks to the bootstrap change in `edge_mining.adapters.infrastructure.api.main_api`.

| Method & Path | Description |
| --- | --- |
| `GET /optimization-units` | Returns every configured unit (`EnergyOptimizationUnitSchema`). |
| `POST /optimization-units` | Creates a unit from `EnergyOptimizationUnitCreateSchema`, validating UUIDs and trimming strings. |
| `GET /optimization-units/{unit_id}` | Fetches a single unit; returns 404 if it does not exist. |
| `PUT /optimization-units/{unit_id}` | Updates names, descriptions, and all relationships in one call. |
| `DELETE /optimization-units/{unit_id}` | Removes a unit and returns the deleted representation. |
| `POST /optimization-units/{unit_id}/enable` | Activates the unit via `ConfigurationService.activate_optimization_unit`. |
| `POST /optimization-units/{unit_id}/disable` | Deactivates the unit. |
| `POST /optimization-units/{unit_id}/energy-source` | Assigns an energy source. |
| `POST /optimization-units/{unit_id}/policy` | Assigns an optimization policy. |
| `POST /optimization-units/{unit_id}/miners` / `POST .../miners/single` / `DELETE .../miners/{miner_id}` | Bulk assign, add, or remove miners. |
| `POST /optimization-units/{unit_id}/notifiers` / `POST .../notifiers/single` / `DELETE .../notifiers/{notifier_id}` | Bulk assign, add, or remove notifiers. |

## How To Interact
### CLI
1. Launch the application entry point (`python -m edge_mining cli interactive`).
2. Navigate to the *Energy Optimization Unit* menu.
3. Use options 1–3 to add, list, or manage units, following the guided prompts.

### REST API
1. Start the FastAPI app (`python -m edge_mining`).
2. Use the swagger to interact with the APIs (using the Fast API Swagger UI at `http://localhost:8001/docs`)
3. Use the enable/disable and assignment routes to mirror the CLI operations programmatically.

## Additional Notes
- The CLI and REST layers both rely on the same `ConfigurationServiceInterface`, ensuring consistent validation and side-effects regardless of the entry point.
- The new error-handling logic in `OptimizationService` makes optimization runs resilient when an adapter or external service is misconfigured, surfacing issues via the shared logger and optional notifications.
- Home forecast providers and performance tracker assignments are scaffolded but still marked for future releases; placeholders are left in both CLI and API flows.
