### PR TITLE
fix: replace critical error handling with warnings for missing entities values in Home Assistant monitors

### DIFF
--- a/edge_mining/adapters/domain/energy/monitors/home_assistant_api.py
+++ b/edge_mining/adapters/domain/energy/monitors/home_assistant_api.py
@@ -310,7 +310,6 @@ class HomeAssistantAPIEnergyMonitor(EnergyMonitorPort):
         if self.logger:
             self.logger.debug("Fetching current energy state from Home Assistant...")
         now = Timestamp(datetime.now())
-        has_critical_error = False
 
         # --- Production ---
         if self.entity_production:
@@ -374,33 +373,35 @@ class HomeAssistantAPIEnergyMonitor(EnergyMonitorPort):
         else:
             grid_watts = None
             if self.entity_grid:
-                has_critical_error = True  # Grid is usually important
+                if self.logger:
+                    self.logger.warning(
+                        f"Could not retrieve grid value (Entity: {self.entity_grid}). "
+                        "Continuing without grid data."
+                    )
 
         # Battery: We want positive for CHARGING, negative for DISCHARGING
         if battery_power_raw is not None:
             battery_power = battery_power_raw if self.battery_positive_charge else -battery_power_raw
         else:
             battery_power = None
-            # Only critical if battery SOC is also configured
             if self.entity_battery_soc and self.entity_battery_power:
-                has_critical_error = True
+                if self.logger:
+                    self.logger.warning(
+                        f"Could not retrieve battery power value "
+                        f"(Entity: {self.entity_battery_power}). "
+                        "Continuing without battery data."
+                    )
 
         # Check if essential values are missing
         if production_watts is None and self.entity_production:
             if self.logger:
-                self.logger.error(f"Missing critical value: Production (Entity: {self.entity_production})")
-            has_critical_error = True
+                self.logger.warning(
+                    f"Could not retrieve production value (Entity: {self.entity_production}). "
+                    "Defaulting to 0W."
+                )
         if consumption_watts is None and self.entity_consumption:
             if self.logger:
                 self.logger.error(f"Missing critical value: House Consumption (Entity: {self.entity_consumption})")
-            has_critical_error = True
-
-        if has_critical_error:
-            if self.logger:
-                self.logger.error(
-                    "Failed to retrieve one or more critical energy values from Home Assistant. Cannot create snapshot."
-                )
-            return None
 
         reading_timestamp = now
 

--- a/edge_mining/adapters/domain/energy/monitors/home_assistant_mqtt.py
+++ b/edge_mining/adapters/domain/energy/monitors/home_assistant_mqtt.py
@@ -344,7 +344,6 @@ class MqttEnergyMonitor(EnergyMonitorPort):
 
         now = datetime.now(timezone.utc)
         snapshot_time = Timestamp(now.astimezone())  # Convert to local timezone for snapshot
-        has_critical_error = False
         is_stale = False
 
         # Get the latest values and check if they are stale
@@ -359,39 +358,35 @@ class MqttEnergyMonitor(EnergyMonitorPort):
         # Check if critical data is missing (never received)
         if self.topics_map.get("solar_production") and production is None:
             if self.logger:
-                self.logger.error(
-                    f"Missing critical value: Solar Production (Topic: {self.topics_map['solar_production']})"
+                self.logger.warning(
+                    f"Could not retrieve Solar Production (Topic: {self.topics_map['solar_production']}). "
+                    "Defaulting to 0W."
                 )
-            has_critical_error = True
         if self.topics_map.get("house_consumption") and consumption is None:
             if self.logger:
                 self.logger.error(
                     f"Missing critical value: House Consumption (Topic: {self.topics_map['house_consumption']})"
                 )
-            has_critical_error = True
         if self.topics_map.get("grid_power") and grid_power is None:
             if self.logger:
-                self.logger.error(f"Missing critical value: Grid Power (Topic: {self.topics_map['grid_power']})")
-            has_critical_error = True
-        # Battery is critical only if both SOC and Power are required and missing
+                self.logger.warning(
+                    f"Could not retrieve Grid Power (Topic: {self.topics_map['grid_power']}). "
+                    "Continuing without grid data."
+                )
+        # Battery: log warning if configured but missing
         if self.topics_map.get("battery_soc") and self.topics_map.get("battery_power"):
             if battery_soc is None:
                 if self.logger:
-                    self.logger.error(f"Missing critical value: Battery SOC (Topic: {self.topics_map['battery_soc']})")
-                has_critical_error = True
+                    self.logger.warning(
+                        f"Could not retrieve Battery SOC (Topic: {self.topics_map['battery_soc']}). "
+                        "Continuing without battery data."
+                    )
             if battery_power is None:
                 if self.logger:
-                    self.logger.error(
-                        f"Missing critical value: Battery Power (Topic: {self.topics_map['battery_power']})"
+                    self.logger.warning(
+                        f"Could not retrieve Battery Power (Topic: {self.topics_map['battery_power']}). "
+                        "Continuing without battery data."
                     )
-                has_critical_error = True
-
-        if has_critical_error:
-            if self.logger:
-                self.logger.error(
-                    "One or more critical energy values were never received via MQTT. Cannot create snapshot."
-                )
-            return None
 
         if is_stale:
             if self.logger:

--- a/edge_mining/adapters/domain/forecast/providers/home_assistant_api.py
+++ b/edge_mining/adapters/domain/forecast/providers/home_assistant_api.py
@@ -326,7 +326,6 @@ class HomeAssistantForecastProvider(ForecastProviderPort):
         """Fetches the energy production forecast."""
         if self.logger:
             self.logger.debug("Fetching forecast energy state from Home Assistant...")
-        has_critical_error = False
 
         # --- Actual Power h ---
         if self.entity_forecast_power_actual_h:
@@ -433,29 +432,21 @@ class HomeAssistantForecastProvider(ForecastProviderPort):
         else:
             energy_remaining_today = None
 
-        # Check if essential values are missing
+        # Check if essential values are missing - log warnings but continue with partial data
         if energy_today is None and self.entity_forecast_energy_today:
             if self.logger:
-                self.logger.error(
-                    f"Missing critical value: Solar Production (Entity: {self.entity_forecast_energy_today})"
+                self.logger.warning(
+                    f"Could not retrieve forecast energy today (Entity: {self.entity_forecast_energy_today}). "
+                    "Continuing with partial forecast data."
                 )
-            has_critical_error = True
         if energy_tomorrow is None and self.entity_forecast_energy_tomorrow:
             if self.logger:
-                self.logger.error(
-                    f"Missing critical value: Solar Production (Entity: {self.entity_forecast_energy_tomorrow})"
+                self.logger.warning(
+                    f"Could not retrieve forecast energy tomorrow (Entity: {self.entity_forecast_energy_tomorrow}). "
+                    "Continuing with partial forecast data."
                 )
-            has_critical_error = True
 
         # Add here other checks for critical values as needed
-
-        if has_critical_error:
-            if self.logger:
-                self.logger.error(
-                    "Failed to retrieve one or more critical energy values "
-                    "from Home Assistant. Cannot create forecast data."
-                )
-            return None
 
         now = Timestamp(datetime.now())
         actual_hour = datetime.now().replace(minute=0, second=0, microsecond=0)


### PR DESCRIPTION
## Problem

When fetching energy state or forecast data from Home Assistant, a single entity returning `unavailable` or `unknown` (e.g. `sensor.battery_soc`) caused the **entire** data retrieval to fail and return `None`. This meant:

- Optimization cycles were skipped entirely, even when most sensor data was valid.
- Frontend real-time updates were blocked due to a single temporarily unavailable sensor.
- The system was fragile against common HA transient states (restarts, integration reloads, Zigbee/Z-Wave timeouts).

The root cause was a `has_critical_error` flag that was set to `True` for **any** configured-but-unavailable entity, triggering `return None` and discarding all successfully retrieved data — despite the domain model already supporting partial data (`EnergyStateSnapshot.battery` and `.grid` are `Optional`).

This PR closes #69 

## Solution

Removed the `has_critical_error` mechanism entirely. Each entity failure is now handled independently with graceful degradation:

| Entity | Previous behavior | New behavior |
|---|---|---|
| `consumption` | Critical → `return None` | Logs error, defaults to `0W`, snapshot still created |
| `production` | Critical → `return None` | Logs warning, defaults to `0W` |
| `grid` | Critical → `return None` | Logs warning, `GridState` set to `None` |
| `battery_soc` / `battery_power` | Critical → `return None` | Logs warning, `BatteryState` set to `None` |
| `energy_today` / `energy_tomorrow` (forecast) | Critical → `return None` | Logs warning, partial forecast returned |

The snapshot is now **always** constructed with whatever data is available. Missing optional components result in `None` sub-objects, which downstream consumers (policy rules, decisional context, frontend) already handle.

## Changes

### `adapters/domain/energy/monitors/home_assistant_api.py`
- Removed `has_critical_error` flag and the early `return None` block.
- Grid unavailability: changed from `has_critical_error = True` to a warning log. `GridState` will be `None`.
- Battery unavailability: changed from `has_critical_error = True` to a warning log. `BatteryState` will be `None`.
- Production unavailability: changed from error to warning log. Defaults to `0W`.
- Consumption unavailability: logs error but no longer blocks the snapshot.

### `adapters/domain/energy/monitors/home_assistant_mqtt.py`
- Removed `has_critical_error` flag and the early `return None` block.
- Solar production, grid power, battery SOC/power: all changed from critical errors to warning logs.
- Consumption: logs error but snapshot is still created.

### `adapters/domain/forecast/providers/home_assistant_api.py`
- Removed `has_critical_error` flag and the early `return None` block.
- `energy_today` and `energy_tomorrow`: changed from critical errors to warning logs.
- Forecast is always returned with whatever data is available.

## Testing

- Verified that when all HA entities respond correctly, the snapshot is unchanged.
- Verified that when a single entity (e.g. battery) returns `unavailable`, the snapshot is still created with `battery=None` and all other fields populated.
- Verified that warning/error logs are correctly emitted for each unavailable entity.