### PR TITLE
fix: automatic create database directory for SQLAlchemy connector

### DIFF
--- a/edge_mining/bootstrap.py
+++ b/edge_mining/bootstrap.py
@@ -124,6 +124,11 @@ def configure_persistence(logger: LoggerPort, settings: AppSettings) -> Persiste
         policies_persistence_adapter,
     ]:
         db_url = settings.db_path
+        if db_url.startswith("sqlite:///"):
+            db_dir = os.path.dirname(db_url.replace("sqlite:///", ""))
+            if db_dir and not os.path.exists(db_dir):
+                logger.debug(f"Creating database directory: {db_dir}")
+                os.makedirs(db_dir, exist_ok=True)
 
         logger.debug(f"Using SQLAlchemy persistence adapter (DB URL: {db_url}).")
         sqlalchemy_db = BaseSQLAlchemyRepository(


### PR DESCRIPTION
## Description

Following a bug report #74 , it was identified that the application crashes at startup if the `/data/db` directory (or any custom SQLite path) does not exist.

While the legacy `SQLITE` persistence adapter correctly handled directory creation, this logic was accidentally omitted during the migration to the `SQLALCHEMY` adapter. SQLAlchemy's SQLite engine expects the target directory to exist beforehand, leading to an `OperationalError` when the path is missing.

### Changes

- Re-implemented the directory presence check within the `SQLALCHEMY` persistence configuration.
- Added logic to parse the `db_url` (specifically for `sqlite:///` schemes) to extract the directory path.
- Used `os.makedirs(db_dir, exist_ok=True)` to ensure the path is created safely before the repository is initialized.
- Added debug logging to confirm directory creation during the bootstrap phase.

### Testing

- Deleted the local `/data/db` folder and verified that the core now creates it automatically on launch.
- Verified that existing databases are not affected.
- Tested with both relative and absolute paths in `settings.db_path`.

This PR closes #74