### PR TITLE
Split Miner Entity into Static Config and Runtime State

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,76 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-rev1]
+
+### Added
+- **`MinerStateSnapshot` Value Object** (`edge_mining/domain/miner/value_objects.py`):
+  - New frozen dataclass representing the runtime operational state of a miner
+  - Fields: `status` (MinerStatus), `hash_rate` (Optional[HashRate]), `power_consumption` (Optional[Watts])
+  - Follows the Single Responsibility Principle: separates real-time state from static configuration
+
+- **`MinerStateSnapshotSchema`** (`edge_mining/adapters/domain/miner/schemas.py`):
+  - Pydantic schema for serialization/deserialization of `MinerStateSnapshot`
+  - Methods: `from_model()`, `to_model()` for domain ↔ schema conversion
+
+### Changed
+- **`Miner` Entity** (`edge_mining/domain/miner/entities.py`):
+  - **BREAKING**: Removed runtime state fields: `status`, `hash_rate`, `power_consumption`
+  - **BREAKING**: Removed methods: `turn_on()`, `turn_off()`, `update_status()`
+  - Simplified `deactivate()` to only set `self.active = False`
+  - Entity now represents only static configuration: `name`, `model`, `hash_rate_max`, `power_consumption_max`, `active`, `controller_id`
+
+- **`DecisionalContext`** (`edge_mining/domain/policy/value_objects.py`):
+  - Added `miner_state: Optional[MinerStateSnapshot]` field for runtime state access
+  - Existing `miner: Optional[Miner]` field retained for static configuration access
+
+- **`OptimizationPolicy`** (`edge_mining/domain/policy/aggregate_roots.py`):
+  - Updated `decide_next_action()` to read status from `decisional_context.miner_state.status` instead of `decisional_context.miner.status`
+
+- **Repositories** (`edge_mining/adapters/domain/miner/repositories.py`):
+  - `SqliteMinerRepository`: Removed `status`, `hash_rate`, `power_consumption` from schema, SQL queries, and row mapping
+  - `SqlAlchemyMinerRepository`: Removed runtime state fields from `update()` method
+
+- **SQLAlchemy Tables** (`edge_mining/adapters/domain/miner/tables.py`):
+  - Removed `MinerStatusType` custom type class
+  - Removed `status`, `hash_rate`, `power_consumption` columns from `miners_table`
+  - Simplified event listeners to only handle `hash_rate_max` and `power_consumption_max`
+
+- **Pydantic Schemas**:
+  - `MinerSchema` (`edge_mining/adapters/domain/miner/schemas.py`): Removed `status`, `hash_rate`, `power_consumption` fields
+  - `MinerCreateSchema`: Removed state fields from creation payload
+  - `DecisionalContextSchema` (`edge_mining/adapters/domain/policy/schemas.py`): Added `miner_state` field with `MinerStateSnapshotSchema`
+
+- **API Router** (`edge_mining/adapters/domain/miner/fast_api/router.py`):
+  - `GET /miners/{miner_id}/status`: Now returns `MinerStateSnapshotSchema` instead of `MinerSchema`
+  - `GET /miner-controllers/{controller_id}/miner-details`: Now returns `MinerStateSnapshotSchema`
+
+- **CLI Commands** (`edge_mining/adapters/domain/miner/cli/commands.py`):
+  - Removed status display from `list_miners()` and `print_miner_details()`
+
+- **Application Interfaces** (`edge_mining/application/interfaces.py`):
+  - `get_miner_status()`: Return type changed from `Optional[MinerStatus]` to `Optional[MinerStateSnapshot]`
+  - `get_miner_details_from_controller()`: Return type changed from `Optional[Miner]` to `Optional[MinerStateSnapshot]`
+  - `add_miner()`: Removed `status` parameter
+
+- **Application Services**:
+  - `MinerActionService` (`edge_mining/application/services/miner_action_service.py`): Refactored all methods to build and return `MinerStateSnapshot` instead of mutating/persisting the `Miner` entity state
+  - `ConfigurationService` (`edge_mining/application/services/configuration_service.py`): Removed `status` from `add_miner()`
+  - `OptimizationService` (`edge_mining/application/services/optimization_service.py`): Updated context building to create `MinerStateSnapshot` objects; removed `miner.turn_on()`/`miner.turn_off()` calls and state persistence after decisions
+
+- **Rule Engine** (`edge_mining/adapters/infrastructure/rule_engine/schemas.py`):
+  - Updated operator examples from `miner.status` to `miner_state.status`
+
+- **YAML Rule Files** (`data/examples/rules/stop/`):
+  - Updated `advanced_stop_rules.yaml` and `basic_stop_rules.yaml`: Changed field references from `miner.status` to `miner_state.status`
+
+- **Alembic Migration** (`alembic/versions/4e55fe6113c7_initial_schema_with_all_tables.py`):
+  - Removed columns `status`, `hash_rate`, `power_consumption` from `miners` table definition
+  - Removed `MinerStatusType()` reference (custom type no longer exists)
+
+### Fixed
+- Fixed unterminated string literal in `MinerActionServiceInterface` docstring
+
 ## [0.1.0]
 
 ### Added

--- a/alembic/versions/4e55fe6113c7_initial_schema_with_all_tables.py
+++ b/alembic/versions/4e55fe6113c7_initial_schema_with_all_tables.py
@@ -184,11 +184,8 @@ def upgrade() -> None:
         sa.Column("id", sa.String(), nullable=False),
         sa.Column("name", sa.String(), nullable=False),
         sa.Column("model", sa.String(), nullable=True),
-        sa.Column("status", edge_mining.adapters.domain.miner.tables.MinerStatusType(), nullable=False),
         sa.Column("active", sa.Boolean(), nullable=False),
-        sa.Column("hash_rate", sa.String(), nullable=True),
         sa.Column("hash_rate_max", sa.String(), nullable=True),
-        sa.Column("power_consumption", sa.Float(), nullable=True),
         sa.Column("power_consumption_max", sa.Float(), nullable=True),
         sa.Column("controller_id", sa.String(), nullable=True),
         sa.ForeignKeyConstraint(

--- a/data/examples/rules/stop/advanced_stop_rules.yaml
+++ b/data/examples/rules/stop/advanced_stop_rules.yaml
@@ -91,7 +91,7 @@ rules:
         - field: "timestamp.hour"
           operator: "eq"
           value: 3  # 3 AM maintenance
-        - field: "miner.status"
+        - field: "miner_state.status"
           operator: "eq"
           value: "ERROR"  # Stop on miner error
         - all_of:  # Sunday early morning maintenance

--- a/data/examples/rules/stop/basic_stop_rules.yaml
+++ b/data/examples/rules/stop/basic_stop_rules.yaml
@@ -45,7 +45,7 @@ rules:
         - field: "timestamp.hour"
           operator: "eq"
           value: 3  # 3 AM maintenance window
-        - field: "miner.status"
+        - field: "miner_state.status"
           operator: "eq"
           value: "ERROR"
     priority: 20
@@ -58,7 +58,7 @@ rules:
         - field: "timestamp.hour"
           operator: "in"
           value: [6, 7, 8]  # Early morning
-        - field: "miner.status"
+        - field: "miner_state.status"
           operator: "eq"
           value: "ERROR"
     priority: 20

--- a/edge_mining/__version__.py
+++ b/edge_mining/__version__.py
@@ -1,4 +1,4 @@
 """Edge Mining version information."""
 
-__version__ = "0.1.0"
-__version_info__ = tuple(int(x) for x in __version__.split("."))
+__version__ = "0.1.0-rev1"
+__version_info__ = tuple(str(x) for x in __version__.split("."))

--- a/edge_mining/adapters/domain/miner/cli/commands.py
+++ b/edge_mining/adapters/domain/miner/cli/commands.py
@@ -13,7 +13,7 @@ from edge_mining.adapters.infrastructure.external_services.cli.commands import (
 from edge_mining.adapters.utils import run_async_func
 from edge_mining.application.interfaces import ConfigurationServiceInterface, MinerActionServiceInterface
 from edge_mining.domain.common import EntityId, Watts
-from edge_mining.domain.miner.common import MinerControllerAdapter, MinerControllerProtocol, MinerStatus
+from edge_mining.domain.miner.common import MinerControllerAdapter, MinerControllerProtocol
 from edge_mining.domain.miner.entities import Miner, MinerController
 from edge_mining.domain.miner.value_objects import HashRate
 from edge_mining.shared.adapter_configs.miner import (
@@ -122,11 +122,6 @@ def list_miners(configuration_service: ConfigurationServiceInterface):
                 + click.style(f"{model_str}, ", fg="white")
                 + "ID: "
                 + click.style(f"{m.id}, ", fg="yellow")
-                + "Status: "
-                + click.style(
-                    f"{m.status.name}, ",
-                    fg=f"{'green' if m.status == MinerStatus.ON else 'red'}",
-                )
                 + "Max Power: "
                 + click.style(f"{m.power_consumption_max}W, ", fg="cyan")
                 + "Max HashRate: "
@@ -501,13 +496,6 @@ def print_miner_details(
     click.echo("")
     click.echo("| Name: " + click.style(miner.name, fg="blue"))
     click.echo("| ID: " + click.style(miner.id, fg="yellow"))
-    click.echo(
-        "| Status: "
-        + click.style(
-            miner.status.name,
-            fg="green" if miner.status == MinerStatus.ON else "red",
-        )
-    )
     click.echo(
         "| Max HashRate: " + str(miner.hash_rate_max.value)
         if miner.hash_rate_max

--- a/edge_mining/adapters/domain/miner/fast_api/router.py
+++ b/edge_mining/adapters/domain/miner/fast_api/router.py
@@ -12,6 +12,7 @@ from edge_mining.adapters.domain.miner.schemas import (
     MinerControllerUpdateSchema,
     MinerCreateSchema,
     MinerSchema,
+    MinerStateSnapshotSchema,
     MinerUpdateSchema,
 )
 
@@ -271,22 +272,20 @@ async def stop_miner(
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
-@router.get("/miners/{miner_id}/status", response_model=MinerSchema)
+@router.get("/miners/{miner_id}/status", response_model=MinerStateSnapshotSchema)
 async def get_miner_status(
     miner_id: EntityId,
     config_service: Annotated[ConfigurationServiceInterface, Depends(get_config_service)],
     action_service: Annotated[MinerActionServiceInterface, Depends(get_miner_action_service)],
-) -> MinerSchema:
+) -> MinerStateSnapshotSchema:
     """Get the current status of a miner."""
     try:
-        _ = await action_service.get_miner_status(miner_id)
+        snapshot = await action_service.get_miner_status(miner_id)
 
-        miner = config_service.get_miner(miner_id)
-
-        if miner is None:
+        if snapshot is None:
             raise MinerNotFoundError(f"Miner with ID {miner_id} not found")
 
-        response = MinerSchema.from_model(miner)
+        response = MinerStateSnapshotSchema.from_model(snapshot)
 
         return response
     except MinerNotFoundError as e:
@@ -489,19 +488,19 @@ async def get_miner_controller(
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
-@router.get("/miner-controllers/{controller_id}/miner-details", response_model=MinerSchema)
+@router.get("/miner-controllers/{controller_id}/miner-details", response_model=MinerStateSnapshotSchema)
 async def get_miner_details_from_controller(
     controller_id: EntityId,
     action_service: Annotated[MinerActionServiceInterface, Depends(get_miner_action_service)],
-) -> MinerSchema:
+) -> MinerStateSnapshotSchema:
     """Get miner details directly from a specific controller."""
     try:
-        miner = await action_service.get_miner_details_from_controller(controller_id)
+        snapshot = await action_service.get_miner_details_from_controller(controller_id)
 
-        if miner is None:
+        if snapshot is None:
             raise MinerControllerNotFoundError(f"Miner controller with ID {controller_id} not found")
 
-        response = MinerSchema.from_model(miner)
+        response = MinerStateSnapshotSchema.from_model(snapshot)
 
         return response
     except MinerControllerNotFoundError as e:

--- a/edge_mining/adapters/domain/miner/repositories.py
+++ b/edge_mining/adapters/domain/miner/repositories.py
@@ -11,7 +11,7 @@ from edge_mining.adapters.domain.miner.tables import miner_controllers_table, mi
 from edge_mining.adapters.infrastructure.persistence.sqlalchemy.base import BaseSQLAlchemyRepository
 from edge_mining.adapters.infrastructure.persistence.sqlite import BaseSqliteRepository
 from edge_mining.domain.common import EntityId, Watts
-from edge_mining.domain.miner.common import MinerControllerAdapter, MinerStatus
+from edge_mining.domain.miner.common import MinerControllerAdapter
 from edge_mining.domain.miner.entities import Miner, MinerController
 from edge_mining.domain.miner.exceptions import (
     MinerControllerAlreadyExistsError,
@@ -80,11 +80,8 @@ class SqliteMinerRepository(MinerRepository):
         "id": "TEXT PRIMARY KEY",
         "name": "TEXT NOT NULL",
         "model": "TEXT",  # Miner model/hardware identifier
-        "status": "TEXT NOT NULL",
         "active": "INTEGER NOT NULL DEFAULT 1 CHECK(active IN (0,1))",
-        "hash_rate": "TEXT",  # JSON object of HashRate dict
         "hash_rate_max": "TEXT",  # JSON object of HashRate dict
-        "power_consumption": "REAL",
         "power_consumption_max": "REAL",
         "controller_id": "TEXT",  # Foreign key to miner controller
     }
@@ -115,22 +112,16 @@ class SqliteMinerRepository(MinerRepository):
         if not row:
             return None
         try:
-            # Deserialize hash_rate from the database row
-            hash_rate_data = json.loads(row["hash_rate"]) if row["hash_rate"] else None
             hash_rate_max_data = json.loads(row["hash_rate_max"]) if row["hash_rate_max"] else None
 
-            hash_rate = self._dict_to_hashrate(hash_rate_data) if hash_rate_data else None
             hash_rate_max = self._dict_to_hashrate(hash_rate_max_data) if hash_rate_max_data else None
 
             return Miner(
                 id=EntityId(row["id"]),
                 name=row["name"] if row["name"] is not None else "",
                 model=row["model"] if row["model"] is not None else None,
-                status=MinerStatus(row["status"]),
                 active=(row["active"] == 1 if row["active"] is not None else False),
-                hash_rate=hash_rate,
                 hash_rate_max=hash_rate_max,
-                power_consumption=(Watts(row["power_consumption"]) if row["power_consumption"] is not None else None),
                 power_consumption_max=(
                     Watts(row["power_consumption_max"]) if row["power_consumption_max"] is not None else None
                 ),
@@ -145,14 +136,13 @@ class SqliteMinerRepository(MinerRepository):
         self.logger.debug(f"Adding miner {miner.id} to SQLite.")
 
         sql = f"""
-            INSERT INTO {self.TABLE_NAME} (id, name, model, status, active, hash_rate, hash_rate_max, power_consumption,
-            power_consumption_max, controller_id)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO {self.TABLE_NAME} (id, name, model, active, hash_rate_max, power_consumption_max,
+            controller_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
         """
         conn = self._db.get_connection()
         try:
-            # Serialize hash_rate to JSON for storage
-            hash_rate_json = json.dumps(self._hashrate_to_dict(miner.hash_rate))
+            # Serialize hash_rate_max to JSON for storage
             hash_rate_max_json = json.dumps(self._hashrate_to_dict(miner.hash_rate_max))
 
             with conn:
@@ -162,11 +152,8 @@ class SqliteMinerRepository(MinerRepository):
                         miner.id,
                         miner.name,
                         miner.model,
-                        miner.status.value,
                         miner.active,
-                        hash_rate_json,
                         hash_rate_max_json,
-                        (float(miner.power_consumption) if miner.power_consumption is not None else 0.0),
                         (float(miner.power_consumption_max) if miner.power_consumption_max is not None else 0.0),
                         miner.controller_id,
                     ),
@@ -229,14 +216,13 @@ class SqliteMinerRepository(MinerRepository):
 
         sql = f"""
             UPDATE {self.TABLE_NAME}
-            SET name = ?, model = ?, status = ?, active = ?, hash_rate = ?, hash_rate_max = ?, power_consumption = ?,
-            power_consumption_max = ?, controller_id = ?
+            SET name = ?, model = ?, active = ?, hash_rate_max = ?, power_consumption_max = ?,
+            controller_id = ?
             WHERE id = ?
         """
         conn = self._db.get_connection()
         try:
-            # Serialize hash_rate to JSON for storage
-            hash_rate_json = json.dumps(self._hashrate_to_dict(miner.hash_rate))
+            # Serialize hash_rate_max to JSON for storage
             hash_rate_max_json = json.dumps(self._hashrate_to_dict(miner.hash_rate_max))
 
             with conn:
@@ -246,11 +232,8 @@ class SqliteMinerRepository(MinerRepository):
                     (
                         miner.name,
                         miner.model,
-                        miner.status.value,
                         miner.active,
-                        hash_rate_json,
                         hash_rate_max_json,
-                        (float(miner.power_consumption) if miner.power_consumption is not None else 0.0),
                         (float(miner.power_consumption_max) if miner.power_consumption_max is not None else 0.0),
                         miner.controller_id,
                         miner.id,
@@ -391,11 +374,8 @@ class SqlAlchemyMinerRepository(MinerRepository):
                 # Update all fields from the new entity
                 existing_entity.name = miner.name
                 existing_entity.model = miner.model
-                existing_entity.status = miner.status
                 existing_entity.active = miner.active
-                existing_entity.hash_rate = miner.hash_rate
                 existing_entity.hash_rate_max = miner.hash_rate_max
-                existing_entity.power_consumption = miner.power_consumption
                 existing_entity.power_consumption_max = miner.power_consumption_max
                 existing_entity.controller_id = miner.controller_id
 

--- a/edge_mining/adapters/domain/miner/schemas.py
+++ b/edge_mining/adapters/domain/miner/schemas.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field, field_serializer, field_validator
 from edge_mining.domain.common import EntityId, Watts
 from edge_mining.domain.miner.common import MinerControllerAdapter, MinerControllerProtocol, MinerStatus
 from edge_mining.domain.miner.entities import Miner, MinerController
-from edge_mining.domain.miner.value_objects import HashRate
+from edge_mining.domain.miner.value_objects import HashRate, MinerStateSnapshot
 from edge_mining.shared.adapter_configs.miner import (
     MinerControllerDummyConfig,
     MinerControllerGenericSocketHomeAssistantAPIConfig,
@@ -53,10 +53,7 @@ class MinerSchema(BaseModel):
     id: str = Field(..., description="Unique identifier for the miner")
     name: str = Field(default="", description="Miner name")
     model: Optional[str] = Field(default=None, description="Miner model/hardware identifier")
-    status: MinerStatus = Field(default=MinerStatus.UNKNOWN, description="Current miner status")
-    hash_rate: Optional[HashRateSchema] = Field(default=None, description="Current hash rate")
     hash_rate_max: Optional[HashRateSchema] = Field(default=None, description="Maximum hash rate")
-    power_consumption: Optional[float] = Field(default=None, description="Current power consumption in Watts")
     power_consumption_max: Optional[float] = Field(default=None, ge=0, description="Maximum power consumption in Watts")
     active: bool = Field(default=True, description="Whether the miner is active in the system")
     controller_id: Optional[str] = Field(default=None, description="ID of the associated Miner controller")
@@ -102,10 +99,6 @@ class MinerSchema(BaseModel):
     @classmethod
     def from_model(cls, miner: Miner) -> "MinerSchema":
         """Create MinerSchema from a Miner domain model instance."""
-        hash_rate: Optional[HashRateSchema] = None
-        if miner.hash_rate:
-            hash_rate = HashRateSchema(value=miner.hash_rate.value, unit=miner.hash_rate.unit)
-
         hash_rate_max: Optional[HashRateSchema] = None
         if miner.hash_rate_max:
             hash_rate_max = HashRateSchema(value=miner.hash_rate_max.value, unit=miner.hash_rate_max.unit)
@@ -114,10 +107,7 @@ class MinerSchema(BaseModel):
             id=str(miner.id),
             name=miner.name,
             model=miner.model,
-            status=miner.status,
-            hash_rate=hash_rate,
             hash_rate_max=hash_rate_max,
-            power_consumption=miner.power_consumption,
             power_consumption_max=miner.power_consumption_max,
             active=miner.active,
             controller_id=str(miner.controller_id) if miner.controller_id else None,
@@ -139,12 +129,9 @@ class MinerSchema(BaseModel):
             id=EntityId(uuid.UUID(self.id)),
             name=self.name,
             model=self.model,
-            status=self.status,
-            hash_rate=(HashRate(value=self.hash_rate.value, unit=self.hash_rate.unit) if self.hash_rate else None),
             hash_rate_max=(
                 HashRate(value=self.hash_rate_max.value, unit=self.hash_rate_max.unit) if self.hash_rate_max else None
             ),
-            power_consumption=Watts(self.power_consumption) if self.power_consumption is not None else None,
             power_consumption_max=Watts(self.power_consumption_max) if self.power_consumption_max is not None else None,
             active=self.active,
             controller_id=EntityId(uuid.UUID(self.controller_id)) if self.controller_id else None,
@@ -158,8 +145,45 @@ class MinerSchema(BaseModel):
         arbitrary_types_allowed = True
         json_encoders = {
             uuid.UUID: str,
-            MinerStatus: lambda v: v.value,
             MinerControllerAdapter: lambda v: v.value,
+        }
+
+
+class MinerStateSnapshotSchema(BaseModel):
+    """Schema for MinerStateSnapshot value object (runtime operational state)."""
+
+    status: MinerStatus = Field(default=MinerStatus.UNKNOWN, description="Current miner status")
+    hash_rate: Optional[HashRateSchema] = Field(default=None, description="Current hash rate")
+    power_consumption: Optional[float] = Field(default=None, description="Current power consumption in Watts")
+
+    @classmethod
+    def from_model(cls, snapshot: MinerStateSnapshot) -> "MinerStateSnapshotSchema":
+        """Create MinerStateSnapshotSchema from a MinerStateSnapshot value object."""
+        hash_rate: Optional[HashRateSchema] = None
+        if snapshot.hash_rate:
+            hash_rate = HashRateSchema(value=snapshot.hash_rate.value, unit=snapshot.hash_rate.unit)
+
+        return cls(
+            status=snapshot.status,
+            hash_rate=hash_rate,
+            power_consumption=snapshot.power_consumption,
+        )
+
+    def to_model(self) -> MinerStateSnapshot:
+        """Convert MinerStateSnapshotSchema to MinerStateSnapshot value object."""
+        return MinerStateSnapshot(
+            status=MinerStatus(self.status) if isinstance(self.status, str) else self.status,
+            hash_rate=(HashRate(value=self.hash_rate.value, unit=self.hash_rate.unit) if self.hash_rate else None),
+            power_consumption=Watts(self.power_consumption) if self.power_consumption is not None else None,
+        )
+
+    class Config:
+        """Pydantic configuration."""
+
+        use_enum_values = True
+        validate_assignment = True
+        json_encoders = {
+            MinerStatus: lambda v: v.value,
         }
 
 
@@ -198,12 +222,9 @@ class MinerCreateSchema(BaseModel):
             id=EntityId(uuid.uuid4()),
             name=self.name,
             model=self.model,
-            status=MinerStatus.UNKNOWN,
-            hash_rate=None,
             hash_rate_max=(
                 HashRate(value=self.hash_rate_max.value, unit=self.hash_rate_max.unit) if self.hash_rate_max else None
             ),
-            power_consumption=None,
             power_consumption_max=Watts(self.power_consumption_max) if self.power_consumption_max is not None else None,
             active=True,
             controller_id=EntityId(uuid.UUID(self.controller_id)) if self.controller_id else None,

--- a/edge_mining/adapters/domain/miner/tables.py
+++ b/edge_mining/adapters/domain/miner/tables.py
@@ -29,13 +29,13 @@ import json
 import uuid
 from typing import Any, Optional
 
-from sqlalchemy import Boolean, Column, Float, ForeignKey, String, Table, TypeDecorator, event
+from sqlalchemy import Boolean, Column, Float, ForeignKey, String, Table, event
 from sqlalchemy.orm import relationship
 
 from edge_mining.adapters.infrastructure.persistence.sqlalchemy.common import ConfigurationType
 from edge_mining.adapters.infrastructure.persistence.sqlalchemy.registry import mapper_registry, metadata
 from edge_mining.domain.common import EntityId, Watts
-from edge_mining.domain.miner.common import MinerControllerAdapter, MinerStatus
+from edge_mining.domain.miner.common import MinerControllerAdapter
 from edge_mining.domain.miner.entities import Miner, MinerController
 from edge_mining.domain.miner.exceptions import MinerControllerConfigurationError
 from edge_mining.domain.miner.value_objects import HashRate
@@ -48,48 +48,6 @@ class MinerControllerConfigType(ConfigurationType):
 
     Inherits from ConfigurationType to handle JSON serialization/deserialization.
     """
-
-
-class MinerStatusType(TypeDecorator):
-    """Custom SQLAlchemy type that converts MinerStatus enum to/from string.
-
-    SQLite doesn't natively support enums, so we need to convert them to strings.
-    """
-
-    impl = String
-    cache_ok = True
-
-    def process_bind_param(self, value: Optional[MinerStatus], dialect) -> Optional[str]:
-        """Convert MinerStatus enum to string before storing in DB.
-
-        Args:
-            value: MinerStatus enum instance or None
-            dialect: SQLAlchemy dialect
-
-        Returns:
-            String value of enum or None
-        """
-        if value is None:
-            return None
-        if isinstance(value, str):
-            return value
-        return value.value  # Get the string value from enum
-
-    def process_result_value(self, value: Optional[str], dialect) -> Optional[MinerStatus]:
-        """Convert string back to MinerStatus enum after loading from DB.
-
-        Args:
-            value: String from database or None
-            dialect: SQLAlchemy dialect
-
-        Returns:
-            MinerStatus enum instance or None
-        """
-        if value is None:
-            return None
-        if isinstance(value, MinerStatus):
-            return value
-        return MinerStatus(value)
 
 
 def _deserialize_miner_controller_config(
@@ -201,13 +159,10 @@ miners_table = Table(
     # Basic attributes
     Column("name", String, nullable=False),
     Column("model", String, nullable=True),
-    Column("status", MinerStatusType, nullable=False, default="UNKNOWN"),
     Column("active", Boolean, nullable=False, default=True),
-    # Hash Rate Value Object - stored as TEXT (JSON) in SQLite to match existing schema
-    Column("hash_rate", String, nullable=True),
+    # Hash Rate Max Value Object - stored as TEXT (JSON) in SQLite to match existing schema
     Column("hash_rate_max", String, nullable=True),
-    # Power Consumption (Watts Value Object stored as float)
-    Column("power_consumption", Float, nullable=True),
+    # Power Consumption Max (Watts Value Object stored as float)
     Column("power_consumption_max", Float, nullable=True),
     # Foreign Key to MinerController
     Column("controller_id", String, ForeignKey("miner_controllers.id"), nullable=True),
@@ -251,18 +206,6 @@ def _receive_miner_load(target: Miner, context) -> None:
         target: The Miner instance being loaded
         context: SQLAlchemy context
     """
-    # SQLAlchemy will load the raw column values as strings/floats
-    # We need to convert them to proper value objects
-
-    # Reconstruct hash_rate (HashRate) from JSON string
-    if hasattr(target, "hash_rate") and target.hash_rate:
-        if isinstance(target.hash_rate, str):
-            try:
-                hash_rate_data = json.loads(target.hash_rate)
-                target.hash_rate = HashRate(value=hash_rate_data.get("value"), unit=hash_rate_data.get("unit", "TH/s"))
-            except (json.JSONDecodeError, TypeError, KeyError):
-                target.hash_rate = None
-
     # Reconstruct hash_rate_max (HashRate) from JSON string
     if hasattr(target, "hash_rate_max") and target.hash_rate_max:
         if isinstance(target.hash_rate_max, str):
@@ -273,11 +216,6 @@ def _receive_miner_load(target: Miner, context) -> None:
                 )
             except (json.JSONDecodeError, TypeError, KeyError):
                 target.hash_rate_max = None
-
-    # Convert power_consumption to Watts (it's loaded as float)
-    if hasattr(target, "power_consumption") and target.power_consumption is not None:
-        if not isinstance(target.power_consumption, type(Watts(0.0))):
-            target.power_consumption = Watts(float(target.power_consumption))
 
     # Convert power_consumption_max to Watts (it's loaded as float)
     if hasattr(target, "power_consumption_max") and target.power_consumption_max is not None:
@@ -295,22 +233,11 @@ def _flatten_miner_value_objects(mapper, connection, target: Miner) -> None:
         connection: Database connection
         target: The Miner instance being persisted
     """
-    # Flatten hash_rate (HashRate) to JSON string
-    if hasattr(target, "hash_rate") and target.hash_rate is not None:
-        if not isinstance(target.hash_rate, str):
-            hash_rate_dict = {"value": target.hash_rate.value, "unit": target.hash_rate.unit}
-            target.hash_rate = json.dumps(hash_rate_dict)  # type: ignore[assignment]
-
     # Flatten hash_rate_max (HashRate) to JSON string
     if hasattr(target, "hash_rate_max") and target.hash_rate_max is not None:
         if not isinstance(target.hash_rate_max, str):
             hash_rate_max_dict = {"value": target.hash_rate_max.value, "unit": target.hash_rate_max.unit}
             target.hash_rate_max = json.dumps(hash_rate_max_dict)  # type: ignore[assignment]
-
-    # Flatten power_consumption (Watts) to float
-    # Watts is a NewType (alias for float), so just ensure it's a float
-    if hasattr(target, "power_consumption") and target.power_consumption is not None:
-        target.power_consumption = float(target.power_consumption)  # type: ignore[assignment]
 
     # Flatten power_consumption_max (Watts) to float
     if hasattr(target, "power_consumption_max") and target.power_consumption_max is not None:
@@ -328,25 +255,14 @@ def _restore_miner_composites(mapper, connection, target: Any) -> None:
         target: The Miner instance that was persisted
     """
     # Restore id to EntityId if it was converted to string
-    # NOTE: After SQLAlchemy flush, IDs may be strings and need restoration to EntityId
     if hasattr(target, "id") and target.id is not None:
         if isinstance(target.id, str):
             target.id = EntityId(uuid.UUID(target.id))
 
     # Restore controller_id to EntityId if needed
-    # NOTE: Foreign key UUIDs may be strings after persist and need conversion
     if hasattr(target, "controller_id") and target.controller_id is not None:
         if isinstance(target.controller_id, str):
             target.controller_id = EntityId(uuid.UUID(target.controller_id))
-
-    # Restore hash_rate from JSON string
-    if hasattr(target, "hash_rate") and target.hash_rate is not None:
-        if isinstance(target.hash_rate, str):
-            try:
-                hash_rate_data = json.loads(target.hash_rate)
-                target.hash_rate = HashRate(value=hash_rate_data.get("value"), unit=hash_rate_data.get("unit", "TH/s"))
-            except (json.JSONDecodeError, TypeError, KeyError):
-                pass
 
     # Restore hash_rate_max from JSON string
     if hasattr(target, "hash_rate_max") and target.hash_rate_max is not None:
@@ -360,10 +276,6 @@ def _restore_miner_composites(mapper, connection, target: Any) -> None:
                 pass
 
     # Restore Watts values
-    if hasattr(target, "power_consumption") and target.power_consumption is not None:
-        if not isinstance(target.power_consumption, type(Watts(0.0))):
-            target.power_consumption = Watts(float(target.power_consumption))
-
     if hasattr(target, "power_consumption_max") and target.power_consumption_max is not None:
         if not isinstance(target.power_consumption_max, type(Watts(0.0))):
             target.power_consumption_max = Watts(float(target.power_consumption_max))

--- a/edge_mining/adapters/domain/policy/schemas.py
+++ b/edge_mining/adapters/domain/policy/schemas.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_valid
 from edge_mining.adapters.domain.energy.schemas import EnergySourceSchema, EnergyStateSnapshotSchema
 from edge_mining.adapters.domain.forecast.schemas import ForecastSchema, SunSchema
 from edge_mining.adapters.domain.home_load.schemas import ConsumptionForecastSchema
-from edge_mining.adapters.domain.miner.schemas import HashRateSchema, MinerSchema
+from edge_mining.adapters.domain.miner.schemas import HashRateSchema, MinerSchema, MinerStateSnapshotSchema
 from edge_mining.adapters.domain.policy.utils import FieldStructureSchema, _extract_schema_structure
 from edge_mining.domain.common import EntityId
 from edge_mining.domain.policy.aggregate_roots import OptimizationPolicy
@@ -466,7 +466,8 @@ class DecisionalContextSchema(BaseModel):
     home_load_forecast: Optional[ConsumptionForecastSchema] = Field(None, description="Home consumption forecast")
     tracker_current_hashrate: Optional[HashRateSchema] = Field(None, description="Current mining hashrate")
     sun: Optional[SunSchema] = Field(None, description="Sun position and timing information")
-    miner: Optional[MinerSchema] = Field(None, description="Miner information")
+    miner: Optional[MinerSchema] = Field(None, description="Miner static configuration")
+    miner_state: Optional[MinerStateSnapshotSchema] = Field(None, description="Miner runtime state snapshot")
     timestamp: datetime = Field(default_factory=datetime.now, description="Timestamp of this decisional context")
 
     @staticmethod
@@ -508,6 +509,7 @@ class DecisionalContextSchema(BaseModel):
             ),
             sun=SunSchema.from_model(context.sun) if context.sun else None,
             miner=MinerSchema.from_model(context.miner) if context.miner else None,
+            miner_state=(MinerStateSnapshotSchema.from_model(context.miner_state) if context.miner_state else None),
             timestamp=context.timestamp,
         )
 
@@ -523,6 +525,7 @@ class DecisionalContextSchema(BaseModel):
             ),
             sun=self.sun.to_model() if self.sun else None,
             miner=self.miner.to_model() if self.miner else None,
+            miner_state=self.miner_state.to_model() if self.miner_state else None,
             timestamp=self.timestamp,
         )
 

--- a/edge_mining/adapters/infrastructure/rule_engine/schemas.py
+++ b/edge_mining/adapters/infrastructure/rule_engine/schemas.py
@@ -123,12 +123,12 @@ OPERATOR_DESCRIPTIONS: Dict[OperatorType, str] = {
 
 OPERATOR_EXAMPLES: Dict[OperatorType, str] = {
     OperatorType.EQ: '{"field": "energy_state.battery.percentage", "operator": "eq", "value": 50}',
-    OperatorType.NE: '{"field": "miner.status", "operator": "ne", "value": "running"}',
+    OperatorType.NE: '{"field": "miner_state.status", "operator": "ne", "value": "running"}',
     OperatorType.GT: '{"field": "energy_state.grid.power", "operator": "gt", "value": 1000}',
     OperatorType.GTE: '{"field": "forecast.total_energy", "operator": "gte", "value": 5000}',
     OperatorType.LT: '{"field": "energy_state.battery.percentage", "operator": "lt", "value": 20}',
     OperatorType.LTE: '{"field": "tracker_current_hashrate", "operator": "lte", "value": 50}',
-    OperatorType.IN: '{"field": "miner.status", "operator": "in", "value": ["running", "mining"]}',
+    OperatorType.IN: '{"field": "miner_state.status", "operator": "in", "value": ["running", "mining"]}',
     OperatorType.NOT_IN: '{"field": "energy_source.type", "operator": "not_in", "value": ["GRID"]}',
     OperatorType.CONTAINS: '{"field": "miner.name", "operator": "contains", "value": "antminer"}',
     OperatorType.STARTS_WITH: '{"field": "energy_source.name", "operator": "starts_with", "value": "solar"}',

--- a/edge_mining/application/interfaces.py
+++ b/edge_mining/application/interfaces.py
@@ -13,10 +13,10 @@ from edge_mining.domain.forecast.common import ForecastProviderAdapter
 from edge_mining.domain.forecast.entities import ForecastProvider
 from edge_mining.domain.forecast.ports import ForecastProviderPort
 from edge_mining.domain.home_load.ports import HomeForecastProviderPort
-from edge_mining.domain.miner.common import MinerControllerAdapter, MinerStatus
+from edge_mining.domain.miner.common import MinerControllerAdapter
 from edge_mining.domain.miner.entities import Miner, MinerController
 from edge_mining.domain.miner.ports import MinerControlPort
-from edge_mining.domain.miner.value_objects import HashRate
+from edge_mining.domain.miner.value_objects import HashRate, MinerStateSnapshot
 from edge_mining.domain.notification.common import NotificationAdapter
 from edge_mining.domain.notification.entities import Notifier
 from edge_mining.domain.notification.ports import NotificationPort
@@ -134,16 +134,16 @@ class MinerActionServiceInterface(ABC):
         """Gets the current hash rate of the specified miner."""
 
     @abstractmethod
-    async def get_miner_status(self, miner_id: EntityId) -> Optional[MinerStatus]:
-        """Gets the current status of the specified miner."""
+    async def get_miner_status(self, miner_id: EntityId) -> Optional[MinerStateSnapshot]:
+        """Gets the current status of the specified miner as a state snapshot."""
 
     @abstractmethod
     async def sync_all_miners(self, include_inactive: bool = False) -> None:
         """Synchronizes the status of all miners from their controllers."""
 
     @abstractmethod
-    async def get_miner_details_from_controller(self, controller_id: EntityId) -> Optional[Miner]:
-        """Get details of a miner from its controller."""
+    async def get_miner_details_from_controller(self, controller_id: EntityId) -> Optional[MinerStateSnapshot]:
+        """Get details of a miner from its controller as a state snapshot."""
 
 
 class ConfigurationServiceInterface(ABC):
@@ -155,7 +155,6 @@ class ConfigurationServiceInterface(ABC):
         self,
         name: str,
         model: Optional[str] = None,
-        status: MinerStatus = MinerStatus.UNKNOWN,
         hash_rate_max: Optional[HashRate] = None,
         power_consumption_max: Optional[Watts] = None,
         controller_id: Optional[EntityId] = None,

--- a/edge_mining/application/services/configuration_service.py
+++ b/edge_mining/application/services/configuration_service.py
@@ -22,7 +22,7 @@ from edge_mining.domain.forecast.ports import ForecastProviderRepository
 from edge_mining.domain.home_load.entities import HomeForecastProvider
 from edge_mining.domain.home_load.exceptions import HomeForecastProviderNotFoundError
 from edge_mining.domain.home_load.ports import HomeForecastProviderRepository
-from edge_mining.domain.miner.common import MinerControllerAdapter, MinerStatus
+from edge_mining.domain.miner.common import MinerControllerAdapter
 from edge_mining.domain.miner.entities import Miner, MinerController
 from edge_mining.domain.miner.exceptions import (
     MinerControllerConfigurationError,
@@ -1210,7 +1210,6 @@ class ConfigurationService(ConfigurationServiceInterface):
         self,
         name: str,
         model: Optional[str] = None,
-        status: MinerStatus = MinerStatus.UNKNOWN,
         hash_rate_max: Optional[HashRate] = None,
         power_consumption_max: Optional[Watts] = None,
         controller_id: Optional[EntityId] = None,
@@ -1229,7 +1228,6 @@ class ConfigurationService(ConfigurationServiceInterface):
         miner = Miner(
             name=name,
             model=model,
-            status=status,
             hash_rate_max=hash_rate_max,
             power_consumption_max=power_consumption_max,
             controller_id=controller_id,

--- a/edge_mining/application/services/miner_action_service.py
+++ b/edge_mining/application/services/miner_action_service.py
@@ -9,10 +9,11 @@ from edge_mining.domain.miner.entities import Miner
 from edge_mining.domain.miner.exceptions import (
     MinerControllerConfigurationError,
     MinerControllerNotFoundError,
+    MinerNotActiveError,
     MinerNotFoundError,
 )
 from edge_mining.domain.miner.ports import MinerRepository
-from edge_mining.domain.miner.value_objects import HashRate
+from edge_mining.domain.miner.value_objects import HashRate, MinerStateSnapshot
 from edge_mining.domain.notification.ports import NotificationPort
 from edge_mining.shared.logging.port import LoggerPort
 
@@ -57,25 +58,20 @@ class MinerActionService(MinerActionServiceInterface):
         if not miner:
             raise MinerNotFoundError(f"Miner with ID {miner_id} not found.")
 
+        if not miner.active:
+            raise MinerNotActiveError(f"Miner {miner_id} is not active and cannot be started.")
+
         # Get the miner controller from the adapter service
         miner_controller = self.adapter_service.get_miner_controller(miner)
 
         if not miner_controller:
             raise MinerControllerConfigurationError(f"Miner controller for miner {miner_id} is not configured.")
 
-        # Update miner status using controller
-        current_status = miner_controller.get_miner_status()
-        current_hashrate = miner_controller.get_miner_hashrate()
-        current_power = miner_controller.get_miner_power()
-        miner.update_status(current_status, current_hashrate, current_power)
-
-        # Update model if available and it has changed
+        # Update model if available and it has changed (static config update)
         current_model = miner_controller.get_model()
         if current_model and miner.model != current_model:
             miner.model = current_model
-
-        # Persist the observed state
-        self.miner_repo.update(miner)
+            self.miner_repo.update(miner)
 
         success = miner_controller.start_miner()
 
@@ -83,9 +79,6 @@ class MinerActionService(MinerActionServiceInterface):
             if self.logger:
                 self.logger.info(f"Miner {miner.id} ({miner.name}) started successfully.")
 
-            # Update domain state
-            miner.turn_on()
-            self.miner_repo.update(miner)
             if notifiers:
                 await self._notify(
                     notifiers,
@@ -108,25 +101,20 @@ class MinerActionService(MinerActionServiceInterface):
         if not miner:
             raise MinerNotFoundError(f"Miner with ID {miner_id} not found.")
 
+        if not miner.active:
+            raise MinerNotActiveError(f"Miner {miner_id} is not active and cannot be stopped.")
+
         # Get the miner controller from the adapter service
         miner_controller = self.adapter_service.get_miner_controller(miner)
 
         if not miner_controller:
             raise MinerControllerConfigurationError(f"Miner controller for miner {miner_id} is not configured.")
 
-        # Update miner status using controller
-        current_status = miner_controller.get_miner_status()
-        current_hashrate = miner_controller.get_miner_hashrate()
-        current_power = miner_controller.get_miner_power()
-        miner.update_status(current_status, current_hashrate, current_power)
-
-        # Update model if available and it has changed
+        # Update model if available and it has changed (static config update)
         current_model = miner_controller.get_model()
         if current_model and miner.model != current_model:
             miner.model = current_model
-
-        # Persist the observed state
-        self.miner_repo.update(miner)
+            self.miner_repo.update(miner)
 
         success = miner_controller.stop_miner()
 
@@ -134,9 +122,6 @@ class MinerActionService(MinerActionServiceInterface):
             if self.logger:
                 self.logger.info(f"Miner {miner.id} ({miner.name}) stopped successfully.")
 
-            # Update domain state
-            miner.turn_off()
-            self.miner_repo.update(miner)
             if notifiers:
                 await self._notify(
                     notifiers,
@@ -165,13 +150,7 @@ class MinerActionService(MinerActionServiceInterface):
         if not miner_controller:
             raise MinerControllerConfigurationError(f"Miner controller for miner {miner_id} is not configured.")
 
-        # Update miner status using controller
-        current_status = miner_controller.get_miner_status()
         current_power = miner_controller.get_miner_power()
-        miner.update_status(new_status=current_status, power=current_power)
-
-        # Persist the observed state
-        self.miner_repo.update(miner)
 
         return current_power
 
@@ -191,23 +170,18 @@ class MinerActionService(MinerActionServiceInterface):
         if not miner_controller:
             raise MinerControllerConfigurationError(f"Miner controller for miner {miner_id} is not configured.")
 
-        # Update miner status using controller
-        current_status = miner_controller.get_miner_status()
         current_hashrate = miner_controller.get_miner_hashrate()
-        miner.update_status(new_status=current_status, hash_rate=current_hashrate)
 
-        # Update model if available and it has changed
+        # Update model if available and it has changed (static config update)
         current_model = miner_controller.get_model()
         if current_model and miner.model != current_model:
             miner.model = current_model
-
-        # Persist the observed state
-        self.miner_repo.update(miner)
+            self.miner_repo.update(miner)
 
         return current_hashrate
 
-    async def get_miner_status(self, miner_id: EntityId) -> MinerStatus:
-        """Gets the current status of the specified miner."""
+    async def get_miner_status(self, miner_id: EntityId) -> MinerStateSnapshot:
+        """Gets the current status of the specified miner as a state snapshot."""
         if self.logger:
             self.logger.info(f"Getting status for miner {miner_id}")
 
@@ -222,32 +196,33 @@ class MinerActionService(MinerActionServiceInterface):
         if not miner_controller:
             raise MinerControllerConfigurationError(f"Miner controller for miner {miner_id} is not configured.")
 
-        # Update miner status using controller
+        # Query current state from controller
         current_status = miner_controller.get_miner_status()
         current_hashrate = miner_controller.get_miner_hashrate()
         current_power = miner_controller.get_miner_power()
-        miner.update_status(current_status, current_hashrate, current_power)
 
-        # Update model if available and it has changed
+        # Update model if available and it has changed (static config update)
         current_model = miner_controller.get_model()
         if current_model and miner.model != current_model:
             miner.model = current_model
+            self.miner_repo.update(miner)
 
-        # Persist the observed state
-        self.miner_repo.update(miner)
-
-        return current_status
+        return MinerStateSnapshot(
+            status=current_status,
+            hash_rate=current_hashrate,
+            power_consumption=current_power,
+        )
 
     async def sync_all_miners(self, include_inactive: bool = False) -> None:
         """Synchronizes the status of all miners from their controllers.
 
-        This method retrieves all miners from the repository and updates their
-        status by querying their respective controllers. Miners without a configured
-        controller or with errors are logged but do not block the synchronization
-        of other miners.
+        This method retrieves all miners from the repository and queries their
+        respective controllers. Miners without a configured controller or with
+        errors are logged but do not block the synchronization of other miners.
 
-        This is typically called during application startup to ensure the system
-        state reflects the actual hardware state.
+        Static configuration (model) is updated if detected from the controller.
+        Runtime state (status, hashrate, power) is not persisted — it is
+        captured in MinerStateSnapshot as needed by consumers.
         """
         if self.logger:
             self.logger.info("Starting synchronization of all miners status...")
@@ -280,19 +255,16 @@ class MinerActionService(MinerActionServiceInterface):
                     error_count += 1
                     continue
 
-                # Update miner status using controller
+                # Query current state from controller (for logging purposes)
                 current_status = miner_controller.get_miner_status()
                 current_hashrate = miner_controller.get_miner_hashrate()
                 current_power = miner_controller.get_miner_power()
-                miner.update_status(current_status, current_hashrate, current_power)
 
-                # Update model if available and it has changed
+                # Update model if available and it has changed (static config update)
                 current_model = miner_controller.get_model()
                 if current_model and miner.model != current_model:
                     miner.model = current_model
-
-                # Persist the observed state
-                self.miner_repo.update(miner)
+                    self.miner_repo.update(miner)
 
                 synced_count += 1
 
@@ -314,8 +286,8 @@ class MinerActionService(MinerActionServiceInterface):
         if self.logger:
             self.logger.info(f"Miners status synchronization completed: {synced_count} synced, {error_count} errors.")
 
-    async def get_miner_details_from_controller(self, controller_id: EntityId) -> Miner:
-        """Get details of a miner from its controller."""
+    async def get_miner_details_from_controller(self, controller_id: EntityId) -> MinerStateSnapshot:
+        """Get details of a miner from its controller as a state snapshot."""
         if self.logger:
             self.logger.info(f"Getting miner details from controller {controller_id}")
 
@@ -323,7 +295,6 @@ class MinerActionService(MinerActionServiceInterface):
         temp_miner = Miner(
             name="Unknown",
             model="Unknown",
-            status=MinerStatus.UNKNOWN,
             hash_rate_max=None,
             power_consumption_max=None,
             controller_id=controller_id,
@@ -337,14 +308,12 @@ class MinerActionService(MinerActionServiceInterface):
             raise MinerControllerNotFoundError(f"Controller with ID {controller_id} not found.")
 
         # Retrieve details from the controller
-        current_model = miner_controller.get_model()
         current_status = miner_controller.get_miner_status()
         current_hashrate = miner_controller.get_miner_hashrate()
         current_power = miner_controller.get_miner_power()
 
         has_no_details = all(
             (
-                not current_model,
                 current_status == MinerStatus.UNKNOWN,
                 current_hashrate is None,
                 current_power is None,
@@ -362,19 +331,13 @@ class MinerActionService(MinerActionServiceInterface):
                 f"{controller_id}. Check controller connectivity and configuration."
             )
 
-        miner = Miner(
-            name="",
-            model=current_model,
+        snapshot = MinerStateSnapshot(
             status=current_status,
-            hash_rate_max=None,
             hash_rate=current_hashrate,
-            power_consumption_max=None,
             power_consumption=current_power,
-            controller_id=controller_id,
-            active=True,
         )
 
         if self.logger:
             self.logger.debug(f"Retrieved miner details for controller {controller_id}")
 
-        return miner
+        return snapshot

--- a/edge_mining/application/services/optimization_service.py
+++ b/edge_mining/application/services/optimization_service.py
@@ -27,7 +27,7 @@ from edge_mining.domain.miner.common import MinerStatus
 from edge_mining.domain.miner.entities import Miner
 from edge_mining.domain.miner.exceptions import MinerError
 from edge_mining.domain.miner.ports import MinerControlPort, MinerRepository
-from edge_mining.domain.miner.value_objects import HashRate
+from edge_mining.domain.miner.value_objects import HashRate, MinerStateSnapshot
 from edge_mining.domain.notification.ports import NotificationPort
 from edge_mining.domain.optimization_unit.aggregate_roots import EnergyOptimizationUnit
 from edge_mining.domain.optimization_unit.exceptions import OptimizationUnitNotFoundError
@@ -227,6 +227,7 @@ class OptimizationService(OptimizationServiceInterface):
             miner_ids = optimization_unit.target_miner_ids
 
             miner: Optional[Miner] = None
+            miner_state: Optional[MinerStateSnapshot] = None
             for miner_id in miner_ids:
                 # --- Miner ---
                 miner = self.miner_repo.get_by_id(miner_id)
@@ -262,19 +263,19 @@ class OptimizationService(OptimizationServiceInterface):
                         )
                     continue  # Try next miner if available
 
-                # Update miner status using controller
+                # Query current state from controller
                 current_status = miner_controller.get_miner_status()
                 current_hashrate = miner_controller.get_miner_hashrate()
                 current_power = miner_controller.get_miner_power()
 
-                # Update the domain model
-                miner.update_status(
-                    new_status=current_status,
+                # Build the miner state snapshot
+                miner_state = MinerStateSnapshot(
+                    status=current_status,
                     hash_rate=current_hashrate,
-                    power=current_power,
+                    power_consumption=current_power,
                 )
 
-                # Update model if available and it has changed
+                # Update model if available and it has changed (static config update)
                 current_model = miner_controller.get_model()
                 if current_model and miner.model != current_model:
                     miner.model = current_model
@@ -328,6 +329,7 @@ class OptimizationService(OptimizationServiceInterface):
             tracker_current_hashrate=tracker_current_hashrate,
             sun=sun,
             miner=miner,
+            miner_state=miner_state,
         )
 
         return context
@@ -678,25 +680,23 @@ class OptimizationService(OptimizationServiceInterface):
 
         # Get current status and make decision
         try:
-            # Update miner status using controller
+            # Query current state from controller
             current_status = miner_controller.get_miner_status()
             current_hashrate = miner_controller.get_miner_hashrate()
             current_power = miner_controller.get_miner_power()
 
-            # Update the domain model
-            miner.update_status(
-                new_status=current_status,
+            # Build the miner state snapshot
+            miner_state = MinerStateSnapshot(
+                status=current_status,
                 hash_rate=current_hashrate,
-                power=current_power,
+                power_consumption=current_power,
             )
 
-            # Update model if available and it has changed
+            # Update model if available and it has changed (static config update)
             current_model = miner_controller.get_model()
             if current_model and miner.model != current_model:
                 miner.model = current_model
-
-            # Persist the observed state
-            self.miner_repo.update(miner)
+                self.miner_repo.update(miner)
 
             # Creates a copy of the context with the miner included, so that the policy
             # can access miner-specific data, without modifying the original context.
@@ -709,7 +709,8 @@ class OptimizationService(OptimizationServiceInterface):
                 home_load_forecast=context.home_load_forecast,
                 tracker_current_hashrate=context.tracker_current_hashrate,
                 sun=context.sun,
-                miner=miner,  # Add the miner to the context
+                miner=miner,  # Static config
+                miner_state=miner_state,  # Runtime state snapshot
             )
 
             # Create the rule engine instance
@@ -827,18 +828,6 @@ class OptimizationService(OptimizationServiceInterface):
                     f"Command {decision.name} for miner {miner_id} failed using controller {type(controller).__name__}."
                 )
         elif action_taken and success:
-            # We might want to update the expected state in the miner entity here,
-            # and then the next iteration will confirm with get_miner_status.
-            miner = self.miner_repo.get_by_id(miner_id)
-            if miner:
-                if decision == MiningDecision.START_MINING:
-                    miner.turn_on()
-                elif decision == MiningDecision.STOP_MINING:
-                    miner.turn_off()
-                self.miner_repo.update(miner)  # If the repo needs to track the state
-            if miner:
-                if decision == MiningDecision.START_MINING:
-                    miner.turn_on()
-                elif decision == MiningDecision.STOP_MINING:
-                    miner.turn_off()
-                self.miner_repo.update(miner)  # If the repo needs to track the state
+            # State is no longer persisted on the Miner entity.
+            # The next optimization iteration will query the controller for current status.
+            pass

--- a/edge_mining/domain/miner/entities.py
+++ b/edge_mining/domain/miner/entities.py
@@ -4,70 +4,27 @@ from dataclasses import dataclass
 from typing import Optional
 
 from edge_mining.domain.common import Entity, EntityId, Watts
-from edge_mining.domain.miner.common import MinerControllerAdapter, MinerStatus
-from edge_mining.domain.miner.exceptions import MinerNotActiveError
+from edge_mining.domain.miner.common import MinerControllerAdapter
 from edge_mining.domain.miner.value_objects import HashRate
 from edge_mining.shared.interfaces.config import MinerControllerConfig
 
 
 @dataclass
 class Miner(Entity):
-    """Entity for a miner."""
+    """Entity for a miner.
+
+    Represents the physical mining asset and its intrinsic (static) properties.
+    Runtime operational state (status, current hash rate, current power consumption)
+    is captured separately in MinerStateSnapshot.
+    """
 
     name: str = ""
     model: Optional[str] = None
-    status: MinerStatus = MinerStatus.UNKNOWN
-    hash_rate: Optional[HashRate] = None  # Hash rate in GH/s or TH/s
     hash_rate_max: Optional[HashRate] = None  # Max hash rate for the miner
-    power_consumption: Optional[Watts] = None  # Can be dynamic or fixed
     power_consumption_max: Optional[Watts] = None  # Max power consumption for the miner
     active: bool = True  # Is the miner active in the system?
 
     controller_id: Optional[EntityId] = None  # Controller for the miner
-
-    def turn_on(self):
-        """Turn on the miner."""
-        # Domain logic: update status if applicable
-        if self.active:
-            if self.status in [
-                MinerStatus.OFF,
-                MinerStatus.ERROR,
-                MinerStatus.UNKNOWN,
-            ]:
-                self.status = MinerStatus.STARTING
-                print(f"Domain: Miner {self.id} requested to turn ON")
-        else:
-            raise MinerNotActiveError(f"Miner {self.id} is not active and cannot be turned ON.")
-
-    def turn_off(self):
-        """Turn off the miner."""
-        # Domain logic: update status if applicable
-        if self.active:
-            if self.status in [MinerStatus.ON, MinerStatus.ERROR]:
-                self.status = MinerStatus.STOPPING
-                print(f"Domain: Miner {self.id} requested to turn OFF")
-            # Else: Already off or transitioning
-        else:
-            raise MinerNotActiveError(f"Miner {self.id} is not active and cannot be turned OFF.")
-
-    def update_status(
-        self,
-        new_status: MinerStatus,
-        hash_rate: Optional[HashRate] = None,
-        power: Optional[Watts] = None,
-    ):
-        """Update the status of the miner."""
-        if self.active:
-            self.status = new_status
-            if hash_rate is not None:
-                self.hash_rate = hash_rate
-            if power is not None:
-                self.power_consumption = power
-
-            # TODO: Add logic to handle max hash rate and power consumption
-            print(f"Domain: Miner {self.id} status updated to {new_status}, hashrate: {hash_rate}, power: {power}")
-        else:
-            raise MinerNotActiveError(f"Miner {self.id} is not active and cannot update status.")
 
     def activate(self):
         """Activate the miner."""
@@ -77,12 +34,6 @@ class Miner(Entity):
     def deactivate(self):
         """Deactivate the miner."""
         self.active = False
-
-        # Deactivate logic: reset status and properties
-        self.status = MinerStatus.UNKNOWN
-        self.hash_rate = None
-        self.power_consumption = None
-
         print(f"Domain: Miner {self.id} deactivated")
 
 

--- a/edge_mining/domain/miner/value_objects.py
+++ b/edge_mining/domain/miner/value_objects.py
@@ -1,8 +1,10 @@
 """Collection of Value Objects for the Mining Device Management domain of the Edge Mining application."""
 
 from dataclasses import dataclass
+from typing import Optional
 
-from edge_mining.domain.common import ValueObject
+from edge_mining.domain.common import ValueObject, Watts
+from edge_mining.domain.miner.common import MinerStatus
 
 
 @dataclass(frozen=True)
@@ -11,3 +13,17 @@ class HashRate(ValueObject):
 
     value: float  # e.g., TH/s
     unit: str = "TH/s"
+
+
+@dataclass(frozen=True)
+class MinerStateSnapshot(ValueObject):
+    """Value Object representing a snapshot of a miner's operational state at a given moment.
+
+    This is used by the Rule Engine, Policy Rules, and the DecisionalContext
+    for decision-making. It has no repository — it is created on-the-fly
+    from controller data.
+    """
+
+    status: MinerStatus = MinerStatus.UNKNOWN
+    hash_rate: Optional[HashRate] = None
+    power_consumption: Optional[Watts] = None

--- a/edge_mining/domain/policy/aggregate_roots.py
+++ b/edge_mining/domain/policy/aggregate_roots.py
@@ -35,10 +35,10 @@ class OptimizationPolicy(AggregateRoot):
         This is the core decision-making logic.
         """
 
-        if not decisional_context.miner:
-            raise ValueError("Error while evaluating policy: Miner is not set in the context.")
+        if not decisional_context.miner_state:
+            raise ValueError("Error while evaluating policy: Miner state is not set in the context.")
 
-        print(f"Policy '{self.name}': Evaluating state for miner status {decisional_context.miner.status.name}")
+        print(f"Policy '{self.name}': Evaluating state for miner status {decisional_context.miner_state.status.name}")
 
         # Logic:
         # 1. If miner is OFF, check START rules. If any match -> START_MINING
@@ -51,7 +51,7 @@ class OptimizationPolicy(AggregateRoot):
         self.sort_rules()
 
         # Load rules into the rule engine based on miner status
-        if decisional_context.miner.status in [
+        if decisional_context.miner_state.status in [
             MinerStatus.OFF,
             MinerStatus.ERROR,
             MinerStatus.UNKNOWN,
@@ -62,7 +62,7 @@ class OptimizationPolicy(AggregateRoot):
             if rule_engine.evaluate(decisional_context):
                 # If any START rule matches, return START_MINING decision
                 return MiningDecision.START_MINING
-        elif decisional_context.miner.status in [MinerStatus.ON]:
+        elif decisional_context.miner_state.status in [MinerStatus.ON]:
             rule_engine.load_rules(self.stop_rules)
 
             # Evaluate the rules in the rule engine

--- a/edge_mining/domain/policy/value_objects.py
+++ b/edge_mining/domain/policy/value_objects.py
@@ -11,7 +11,7 @@ from edge_mining.domain.forecast.aggregate_root import Forecast
 from edge_mining.domain.forecast.value_objects import Sun
 from edge_mining.domain.home_load.value_objects import ConsumptionForecast
 from edge_mining.domain.miner.entities import Miner
-from edge_mining.domain.miner.value_objects import HashRate
+from edge_mining.domain.miner.value_objects import HashRate, MinerStateSnapshot
 
 
 @dataclass(frozen=True)
@@ -29,4 +29,5 @@ class DecisionalContext(ValueObject):
     sun: Optional[Sun] = field(default=None)
 
     miner: Optional[Miner] = field(default=None)
+    miner_state: Optional[MinerStateSnapshot] = field(default=None)
     timestamp: datetime = field(default_factory=datetime.now)

--- a/tests/unit/adapters/infrastructure/rule_engine/test_rule_evaluator.py
+++ b/tests/unit/adapters/infrastructure/rule_engine/test_rule_evaluator.py
@@ -26,7 +26,8 @@ class TestRuleEvaluator(unittest.TestCase):
         self.mock_context.energy_state.production = 1200
 
         self.mock_context.miner = Mock()
-        self.mock_context.miner.status = "ON"
+        self.mock_context.miner_state = Mock()
+        self.mock_context.miner_state.status = "ON"
 
         self.mock_context.timestamp = datetime(2025, 8, 13, 14, 30)  # Tuesday 14:30
 
@@ -83,7 +84,7 @@ class TestRuleEvaluator(unittest.TestCase):
     def test_convert_conditions_to_schema_rule_condition(self):
         """Test converting dict to RuleConditionSchema."""
         conditions_dict = {
-            "field": "miner.status",
+            "field": "miner_state.status",
             "operator": "eq",
             "value": "ON",
         }
@@ -91,7 +92,7 @@ class TestRuleEvaluator(unittest.TestCase):
         result = RuleEvaluator._convert_conditions_to_schema(conditions_dict)
 
         self.assertIsInstance(result, RuleConditionSchema)
-        self.assertEqual(result.field, "miner.status")
+        self.assertEqual(result.field, "miner_state.status")
         self.assertEqual(result.operator, OperatorType.EQ)
         self.assertEqual(result.value, "ON")
 


### PR DESCRIPTION
Refactoring of the `Miner` entity to separate static configuration from runtime operational state, applying the _Single Responsibility Principle_ (SRP).

- **`Miner`** (Entity) → contains only static configuration: `name`, `model`, `hash_rate_max`, `power_consumption_max`, `active`, `controller_id`
- **`MinerStateSnapshot`** (Value Object) → contains runtime state: `status`, `hash_rate`, `power_consumption`

`MinerStateSnapshot` does not have a dedicated repository. It is built on-demand by querying miner controllers and used by the rule engine (`OptimizationPolicy`, `RuleEngine`) and `DecisionalContext`.

This PR closes #55 

## Motivation

The `Miner` entity had a dual responsibility:
1. Representing the miner's static configuration (persistent data)
2. Tracking the real-time operational state (transient data)

This caused:
- Unnecessary repository saves on every state read
- Coupling between configuration lifecycle and runtime state
- Domain methods (`turn_on`, `turn_off`, `update_status`) that mutated state without real business logic value

## Changes by Layer

### Domain Layer

| File | Change |
|------|--------|
| `domain/miner/value_objects.py` | Added `MinerStateSnapshot` (frozen dataclass) |
| `domain/miner/entities.py` | Removed fields `status`, `hash_rate`, `power_consumption` and methods `turn_on()`, `turn_off()`, `update_status()` |
| `domain/policy/value_objects.py` | Added field `miner_state: Optional[MinerStateSnapshot]` to `DecisionalContext` |
| `domain/policy/aggregate_roots.py` | `decide_next_action()` reads from `miner_state.status` instead of `miner.status` |

### Application Layer

| File | Change |
|------|--------|
| `application/interfaces.py` | Return type of `get_miner_status()` → `Optional[MinerStateSnapshot]`; return type of `get_miner_details_from_controller()` → `Optional[MinerStateSnapshot]`; removed `status` parameter from `add_miner()` |
| `application/services/miner_action_service.py` | All methods build and return `MinerStateSnapshot` instead of mutating the `Miner` entity |
| `application/services/configuration_service.py` | Removed `status` from `add_miner()` |
| `application/services/optimization_service.py` | Context building creates `MinerStateSnapshot`; removed `miner.turn_on()`/`turn_off()` and post-decision state persistence |

### Adapter Layer

| File | Change |
|------|--------|
| `adapters/domain/miner/repositories.py` | Removed runtime fields from `SqliteMinerRepository` and `SqlAlchemyMinerRepository` |
| `adapters/domain/miner/tables.py` | Removed `MinerStatusType` class; removed columns `status`, `hash_rate`, `power_consumption` from `miners_table`; simplified event listeners |
| `adapters/domain/miner/schemas.py` | Removed runtime fields from `MinerSchema` and `MinerCreateSchema`; added `MinerStateSnapshotSchema` |
| `adapters/domain/miner/fast_api/router.py` | Status and details endpoints now return `MinerStateSnapshotSchema` |
| `adapters/domain/miner/cli/commands.py` | Removed status display from miner list and details |
| `adapters/domain/policy/schemas.py` | Added `miner_state` field to `DecisionalContextSchema` |
| `adapters/infrastructure/rule_engine/schemas.py` | Updated operator examples: `miner.status` → `miner_state.status` |

### Data / Config

| File | Change |
|------|--------|
| `data/examples/rules/stop/advanced_stop_rules.yaml` | `miner.status` → `miner_state.status` |
| `data/examples/rules/stop/basic_stop_rules.yaml` | `miner.status` → `miner_state.status` |

### Migrations

| File | Change |
|------|--------|
| `alembic/versions/4e55fe6113c7_initial_schema_with_all_tables.py` | Removed columns `status`, `hash_rate`, `power_consumption` from `miners` table; removed `MinerStatusType()` reference |

### Tests

| File | Change |
|------|--------|
| `tests/unit/adapters/infrastructure/rule_engine/test_rule_evaluator.py` | Updated mock: `mock_context.miner.status` → `mock_context.miner_state.status`; updated field references in test conditions |

## Breaking Changes

1. **`Miner` entity**: removed fields `status`, `hash_rate`, `power_consumption` and methods `turn_on()`, `turn_off()`, `update_status()`
2. **API**: endpoints `/miners/{id}/status` and `/miner-controllers/{id}/miner-details` now return `MinerStateSnapshotSchema` instead of `MinerSchema`/`MinerStatus`
3. **Database**: the `miners` table no longer contains columns `status`, `hash_rate`, `power_consumption` (requires migration for existing databases)
4. **YAML Rules**: references to `miner.status` must be updated to `miner_state.status`
5. **`DecisionalContext`**: access the miner's runtime state via `context.miner_state` instead of `context.miner`

## Test Results

- **Unit tests**: 142 passed
- **Integration tests**: 46 passed
