### PR TITLE
fix: resolve external service update failure when config class is missing

### DIFF
--- a/edge_mining/adapters/infrastructure/external_services/fast_api/router.py
+++ b/edge_mining/adapters/infrastructure/external_services/fast_api/router.py
@@ -163,7 +163,12 @@ async def update_external_service(
 
         configuration: Optional[Configuration] = None
         if external_service_update.config:
-            configuration = ExternalServiceConfig.from_dict(external_service_update.config)
+            config_cls = config_service.get_external_service_config_by_type(external_service.adapter_type)
+            if config_cls is None:
+                raise ExternalServiceConfigurationError(
+                    f"No configuration class found for adapter type {external_service.adapter_type}"
+                )
+            configuration = config_cls.from_dict(external_service_update.config)
 
         # Update the external service
         updated_service = await config_service.update_external_service(


### PR DESCRIPTION
The `PUT /external-services/{id}` endpoint was calling `ExternalServiceConfig.from_dict()` directly on the base class, ignoring the adapter-specific configuration class. This caused incorrect deserialization (or errors) when updating an external service from the frontend.

Fix: The endpoint now resolves the correct config class via `get_external_service_config_by_type()` before deserializing the payload, and returns a 400 error if no config class is registered for that adapter type.

This PR fixes the issue https://github.com/edge-mining/frontend/issues/32